### PR TITLE
Add pull actions with per-individual sub-actions

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Install pip
         run: python -m ensurepip --upgrade
       - name: Install pip tools
-        run: pip install pip-tools
+        # typing_extensions listed explicitly: pip-tools 7.6.0 imports it on
+        # Python 3.10 without declaring it as a dependency
+        run: pip install pip-tools typing_extensions
       - name: Install compile dependencies
         run: pip-compile --output-file=requirements.txt requirements-base.in requirements-dev.in requirements.in
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # gundi-integration-movebank
 This is Gundi's integration for pulling data from Movebank Studies.
 
+## Actions
+
+- **auth** — validates Movebank credentials.
+- **pull_observations** (scheduled, every 10 min) — lists the configured study's
+  individuals and triggers one `pull_events_for_individual` sub-action per individual.
+  `maximum_lookback_hours` (default 24) controls how far back a new individual's
+  first fetch reaches — override it on a manual run to backfill history.
+- **pull_events_for_individual** (internal) — fetches events for one individual with
+  a separate cursor per sensor type (GPS, accessory-measurements), batches requests in
+  adaptive time windows, transforms events into observations, and sends them to Gundi.
+  State lives in Redis keyed by integration/action/individual.
+

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -54,7 +54,7 @@ class Individual(pydantic.BaseModel):
                 val = parse_date(val)
             except Exception:
                 return None
-        return val if val.tzinfo else val.replace(tzinfo=timezone.utc)
+        return val.astimezone(timezone.utc) if val.tzinfo else val.replace(tzinfo=timezone.utc)
 
 
 def generate_individuals(items):

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -46,6 +46,8 @@ class Individual(pydantic.BaseModel):
 
     @pydantic.validator('timestamp_start', 'timestamp_end')
     def clean_timestamp(cls, val):
+        if val is None:
+            return None
         if isinstance(val, str):
             try:
                 val = parse_date(val)

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -1,9 +1,17 @@
+import logging
+from datetime import datetime, timezone
+from typing import Dict, Optional, Union
+
+import pydantic
+from dateutil.parser import parse as parse_date
 from movebank_client import MovebankClient
 from movebank_client.errors import MBClientError, MBForbiddenError
 
 from app.actions.configurations import AuthenticateConfig
 from app.services.errors import ConfigurationNotFound
 from app.services.utils import find_config_for_action
+
+logger = logging.getLogger(__name__)
 
 
 def get_auth_config(integration):
@@ -18,3 +26,65 @@ def get_auth_config(integration):
             f"are missing. Please fix the integration setup in the portal."
         )
     return AuthenticateConfig.parse_obj(auth_config.data)
+
+
+class Individual(pydantic.BaseModel):
+    id: str
+    local_identifier: str
+    nick_name: str
+    ring_id: str
+    sex: str
+    taxon_canonical_name: str
+
+    # Tolerate timestamps with empty-string. Let validator coerce to datetime.
+    timestamp_start: Optional[Union[str, datetime]]
+    timestamp_end: Optional[Union[datetime, str]]
+    number_of_events: Optional[int] = 0
+    number_of_deployments: Optional[int] = 0
+    sensor_type_ids: str
+    taxon_detail: str
+
+    @pydantic.validator('timestamp_start', 'timestamp_end')
+    def clean_timestamp(cls, val):
+        if isinstance(val, str):
+            try:
+                val = parse_date(val)
+            except Exception:
+                return None
+        return val if val.tzinfo else val.replace(tzinfo=timezone.utc)
+
+
+def generate_individuals(items):
+    for item in items:
+        try:
+            val = Individual.parse_obj(item)
+        except Exception:
+            logger.exception('Failed parsing Individual %s', item)
+        else:
+            yield val
+
+
+class SensorState(pydantic.BaseModel):
+    """Cursor for a single sensor type of one individual."""
+    highest_event_id: Optional[int] = 0
+    latest_timestamp: Optional[datetime] = None
+
+
+class IndividualState(pydantic.BaseModel):
+    individual_id: str
+    study_id: str
+    local_identifier: Optional[str] = None
+    # Per-sensor-type cursors (key = sensor_type_id as string, because JSON keys are strings)
+    sensor_states: Dict[str, SensorState] = pydantic.Field(default_factory=dict)
+
+    def get_sensor_state(self, sensor_type_id: int) -> SensorState:
+        key = str(sensor_type_id)
+        if key not in self.sensor_states:
+            self.sensor_states[key] = SensorState()
+        return self.sensor_states[key]
+
+    def update_sensor_state(self, sensor_type_id: int, latest_timestamp: datetime, highest_event_id: int):
+        self.sensor_states[str(sensor_type_id)] = SensorState(
+            latest_timestamp=latest_timestamp,
+            highest_event_id=highest_event_id
+        )

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -7,7 +7,6 @@ from dateutil.parser import parse as parse_date
 from movebank_client import MovebankClient
 from movebank_client.errors import MBClientError, MBForbiddenError
 
-from app.actions.configurations import AuthenticateConfig
 from app.services.errors import ConfigurationNotFound
 from app.services.utils import find_config_for_action
 
@@ -15,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 def get_auth_config(integration):
+    from app.actions.configurations import AuthenticateConfig
+
     # Look for the login credentials, needed for any action
     auth_config = find_config_for_action(
         configurations=integration.configurations,

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -1,11 +1,11 @@
 from pydantic import Field, SecretStr
 
-from app.actions import AuthActionConfiguration, PullActionConfiguration
+from app.actions import AuthActionConfiguration, ExecutableActionMixin, PullActionConfiguration
 from app.actions.client import Individual
 from app.actions.core import InternalActionConfiguration
 
 
-class AuthenticateConfig(AuthActionConfiguration):
+class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
     username: str
     password: SecretStr = Field(..., format="password")
 

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -1,27 +1,33 @@
-from datetime import datetime, timezone
 from pydantic import Field, SecretStr
 
-from app.actions import AuthActionConfiguration, PullActionConfiguration, ExecutableActionMixin
+from app.actions import AuthActionConfiguration, PullActionConfiguration
+from app.actions.client import Individual
+from app.actions.core import InternalActionConfiguration
 
 
-class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
+class AuthenticateConfig(AuthActionConfiguration):
     username: str
     password: SecretStr = Field(..., format="password")
 
 
-class FetchIndividualEventsConfig(PullActionConfiguration):
-    start_time: datetime
-    study_id: int
-    individual_id: int
-
-
-class FetchStudyIndividualsConfig(PullActionConfiguration):
+class PullObservationsConfig(PullActionConfiguration):
     study_id: str = Field(
-        title='Movebank Study IDs',
-        description='ID of the desired Movebank Study.',
+        ...,
+        title="Movebank Study ID",
+        description="ID of the Movebank study to pull observations from.",
     )
-    start_time: datetime = Field(
-        title='Start Datetime',
-        description='Datetime events are going to be fetched from.',
-        default=datetime.now(tz=timezone.utc)
+    maximum_lookback_hours: int = Field(
+        24,
+        title="Maximum Lookback (hours)",
+        description=(
+            "How far back to fetch events for an individual that has no saved state yet. "
+            "Override this on a manual run to backfill historical data."
+        ),
     )
+
+
+class PullEventsForIndividualConfig(InternalActionConfiguration):
+    """Config for the internal sub-action that pulls events for one individual."""
+    study_id: str
+    individual: Individual
+    maximum_lookback_hours: int = 24

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -153,12 +153,16 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
     # Size the fetch window by event density: high-frequency individuals get a
     # window that should hold roughly HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD events,
     # assuming an even distribution over the individual's active range.
-    if ind.number_of_events > HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD and ind.timestamp_end:
+    if (ind.number_of_events or 0) > HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD and ind.timestamp_end:
         total_seconds = (ind.timestamp_end - ind.timestamp_start).total_seconds()
         batch_window_size = timedelta(
             seconds=(HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD / ind.number_of_events) * total_seconds
         )
     else:
+        batch_window_size = DEFAULT_BATCH_WINDOW
+    if batch_window_size <= timedelta(0):
+        # A zero/negative window (timestamp_end <= timestamp_start) would never
+        # advance current_window_start and spin the fetch loop forever.
         batch_window_size = DEFAULT_BATCH_WINDOW
 
     logger.info(
@@ -180,12 +184,17 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
         while current_window_start <= highest_date and total_observations_sent < MAXIMUM_RECORDS_PER_INDIVIDUAL:
             end_at = min(highest_date, current_window_start + batch_window_size)
 
-            # One request per sensor type, each from its own cursor.
+            # One request per sensor type, each from its own cursor. Events are
+            # grouped by the requesting sensor (each fetch is already scoped to
+            # one sensor type), so cursor advancement doesn't depend on Movebank
+            # echoing sensor_type_id back on every event.
             events = []
+            events_by_sensor = {}
             for sensor_type_id in sensor_type_ids:
                 sensor_start = sensor_type_timestamps[sensor_type_id]
                 if sensor_start > end_at:
                     continue  # this sensor is already past the window
+                sensor_events = []
                 async for event in mb.get_individual_events_by_time(
                     study_id=action_config.study_id,
                     individual_id=ind.id,
@@ -194,7 +203,15 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
                     sensor_type_ids=[sensor_type_id],
                     minimum_event_id=minimum_event_ids[sensor_type_id],
                 ):
-                    events.append(event)
+                    sensor_events.append(event)
+                events_by_sensor[sensor_type_id] = sensor_events
+                events.extend(sensor_events)
+
+            if not events_by_sensor:
+                # Every sensor was already past this window: advance without
+                # touching the quiet flag or the saved cursor (v1 behavior).
+                current_window_start = current_window_start + batch_window_size
+                continue
 
             observations = [
                 obs for event in events
@@ -204,12 +221,6 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
                 await send_observations_to_gundi(observations=batch, integration_id=integration_id)
 
             # Advance per-sensor cursors from what actually came back.
-            events_by_sensor = {}
-            for event in events:
-                try:
-                    events_by_sensor.setdefault(int(event.get("sensor_type_id")), []).append(event)
-                except (TypeError, ValueError):
-                    continue
             for sensor_type_id in sensor_type_ids:
                 sensor_events = events_by_sensor.get(sensor_type_id, [])
                 sensor_timestamps = []

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -5,7 +5,6 @@ from app.actions.client import generate_individuals
 from app.actions.configurations import AuthenticateConfig, PullObservationsConfig, PullEventsForIndividualConfig
 from app.services.action_scheduler import crontab_schedule, trigger_action
 from app.services.activity_logger import activity_logger
-from app.services.state import IntegrationStateManager
 
 
 logger = logging.getLogger(__name__)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -7,7 +7,7 @@ import app.services.gundi as gundi_tools
 import app.settings.integration as settings
 import app.actions.client as client
 
-from app.actions.configurations import AuthenticateConfig, FetchStudyIndividualsConfig, FetchIndividualEventsConfig
+from app.actions.configurations import AuthenticateConfig
 from app.services.activity_logger import activity_logger
 from app.services.state import IntegrationStateManager
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -156,8 +156,10 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
     # Size the fetch window by event density: high-frequency individuals get a
     # window that should hold roughly HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD events,
     # assuming an even distribution over the individual's active range.
-    if (ind.number_of_events or 0) > HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD and ind.timestamp_end:
-        total_seconds = (ind.timestamp_end - ind.timestamp_start).total_seconds()
+    if (ind.number_of_events or 0) > HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD:
+        # resolved_individual_timestamp_end falls back to now when the individual
+        # omits timestamp_end, so density sizing works for those individuals too.
+        total_seconds = (resolved_individual_timestamp_end - ind.timestamp_start).total_seconds()
         batch_window_size = timedelta(
             seconds=(HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD / ind.number_of_events) * total_seconds
         )
@@ -249,8 +251,10 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
                 f"events by sensor: { {k: len(v) for k, v in events_by_sensor.items()} }"
             )
 
-            if observations:
-                # Observations were sent above — only now is it safe to advance the saved cursor.
+            if events:
+                # Persist cursors whenever events were processed — sends happened
+                # above, and even if the transform dropped every record, advancing
+                # keeps unusable events from being refetched on the next run.
                 await state_manager.set_state(
                     integration_id,
                     CURSOR_STATE_ACTION_ID,
@@ -258,7 +262,7 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
                     source_id=ind.id,
                 )
             else:
-                # Nothing in this window: back off from this individual for a while.
+                # No events in this window: back off from this individual for a while.
                 await state_manager.set_state(
                     integration_id,
                     QUIET_STATE_ACTION_ID,

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -118,7 +118,7 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
     resolved_individual_timestamp_end = ind.timestamp_end or now
     highest_date = min(now, resolved_individual_timestamp_end)
 
-    sensor_type_labels = [label.lower() for label in ind.sensor_type_ids.split(",")]
+    sensor_type_labels = [label.strip().lower() for label in ind.sensor_type_ids.split(",")]
     sensor_type_ids = [
         MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID[label]
         for label in sensor_type_labels

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1,21 +1,14 @@
-import datetime
-import httpx
 import logging
-import stamina
 
-import app.services.gundi as gundi_tools
-import app.settings.integration as settings
 import app.actions.client as client
-
-from app.actions.configurations import AuthenticateConfig
+from app.actions.client import generate_individuals
+from app.actions.configurations import AuthenticateConfig, PullObservationsConfig, PullEventsForIndividualConfig
+from app.services.action_scheduler import crontab_schedule, trigger_action
 from app.services.activity_logger import activity_logger
 from app.services.state import IntegrationStateManager
 
 
 logger = logging.getLogger(__name__)
-
-
-state_manager = IntegrationStateManager()
 
 
 async def action_auth(integration, action_config: AuthenticateConfig):
@@ -43,3 +36,38 @@ async def action_auth(integration, action_config: AuthenticateConfig):
         else:
             logger.error(f"Auth unsuccessful for integration {integration}.")
             return {"valid_credentials": False}
+
+
+@activity_logger()
+@crontab_schedule("*/10 * * * *")  # same cadence as the v1 cronjob
+async def action_pull_observations(integration, action_config: PullObservationsConfig):
+    """List the study's individuals and trigger one sub-action per individual."""
+    integration_id = str(integration.id)
+    logger.info(f"Pulling observations for study {action_config.study_id}, integration {integration_id}...")
+
+    auth_config = client.get_auth_config(integration)
+    mb_client = client.MovebankClient(
+        base_url=integration.base_url,
+        username=auth_config.username,
+        password=auth_config.password.get_secret_value(),
+    )
+    async with mb_client as mb:
+        individual_rows = await mb.get_individuals_by_study(study_id=action_config.study_id)
+
+    individuals = list(generate_individuals(individual_rows))
+    logger.info(f"{len(individuals)} individuals found for study {action_config.study_id}")
+
+    triggered = 0
+    for ind in individuals:
+        await trigger_action(
+            integration_id=integration_id,
+            action_id="pull_events_for_individual",
+            config=PullEventsForIndividualConfig(
+                study_id=action_config.study_id,
+                individual=ind,
+                maximum_lookback_hours=action_config.maximum_lookback_hours,
+            ),
+        )
+        triggered += 1
+
+    return {"individuals_found": len(individuals), "sub_actions_triggered": triggered}

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -9,7 +9,7 @@ from movebank_client import MovebankClient
 import app.actions.client as client
 from app.actions.client import IndividualState, generate_individuals
 from app.actions.configurations import AuthenticateConfig, PullObservationsConfig, PullEventsForIndividualConfig
-from app.actions.transform import build_observation, chunks
+from app.actions.transform import _ensure_utc, build_observation, chunks
 from app.services.action_scheduler import crontab_schedule, trigger_action
 from app.services.activity_logger import activity_logger
 from app.services.gundi import send_observations_to_gundi
@@ -21,7 +21,10 @@ state_manager = IntegrationStateManager()
 
 # Ported from the v1 integration — production-proven values.
 HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD = 5000  # events; above this, shrink the fetch window
-MAXIMUM_RECORDS_PER_INDIVIDUAL = 2000  # hard cap per individual per run
+# Per-run cap, checked between windows: once total processed reaches this, no
+# further windows are fetched. A single window may overshoot the cap — everything
+# fetched in a window is sent so its cursors can advance consistently.
+MAXIMUM_RECORDS_PER_INDIVIDUAL = 2000
 DEFAULT_BATCH_WINDOW = timedelta(days=5)
 QUIET_PERIOD_SECONDS = 3600  # skip an individual for this long after an empty window
 OBSERVATIONS_BATCH_SIZE = 200
@@ -227,7 +230,7 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
                 sensor_event_ids = []
                 for event in sensor_events:
                     try:
-                        sensor_timestamps.append(parse_date(event.get("timestamp")).replace(tzinfo=timezone.utc))
+                        sensor_timestamps.append(_ensure_utc(parse_date(event.get("timestamp"))))
                     except Exception:
                         pass
                     try:

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1,13 +1,33 @@
+import json
 import logging
+from datetime import datetime, timedelta, timezone
+
+import pydantic
+from dateutil.parser import parse as parse_date
+from movebank_client import MovebankClient
 
 import app.actions.client as client
-from app.actions.client import generate_individuals
+from app.actions.client import IndividualState, generate_individuals
 from app.actions.configurations import AuthenticateConfig, PullObservationsConfig, PullEventsForIndividualConfig
+from app.actions.transform import build_observation, chunks
 from app.services.action_scheduler import crontab_schedule, trigger_action
 from app.services.activity_logger import activity_logger
+from app.services.gundi import send_observations_to_gundi
+from app.services.state import IntegrationStateManager
 
 
 logger = logging.getLogger(__name__)
+state_manager = IntegrationStateManager()
+
+# Ported from the v1 integration — production-proven values.
+HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD = 5000  # events; above this, shrink the fetch window
+MAXIMUM_RECORDS_PER_INDIVIDUAL = 2000  # hard cap per individual per run
+DEFAULT_BATCH_WINDOW = timedelta(days=5)
+QUIET_PERIOD_SECONDS = 3600  # skip an individual for this long after an empty window
+OBSERVATIONS_BATCH_SIZE = 200
+
+CURSOR_STATE_ACTION_ID = "pull_events_for_individual"
+QUIET_STATE_ACTION_ID = "pull_events_for_individual_quiet"
 
 
 async def action_auth(integration, action_config: AuthenticateConfig):
@@ -70,3 +90,170 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         triggered += 1
 
     return {"individuals_found": len(individuals), "sub_actions_triggered": triggered}
+
+
+@activity_logger()
+async def action_pull_events_for_individual(integration, action_config: PullEventsForIndividualConfig):
+    """Fetch events for one individual with per-sensor cursors, transform, and send to Gundi.
+
+    Internal sub-action, triggered by pull_observations once per individual.
+    """
+    ind = action_config.individual
+    integration_id = str(integration.id)
+    log_reference = f"study:{action_config.study_id},individual:{ind.id},local_identifier:{ind.local_identifier}"
+
+    if await state_manager.get_state(integration_id, QUIET_STATE_ACTION_ID, source_id=ind.id):
+        logger.info(f"Skipping individual {log_reference} for quiet period.")
+        return {"skipped": "quiet_period"}
+
+    if ind.timestamp_start is None:
+        logger.info(f"Skip Movebank {log_reference} for no timestamp_start.")
+        return {"skipped": "no_timestamp_start"}
+
+    now = datetime.now(tz=timezone.utc)
+    # Some individuals don't provide timestamp_end, so resolve a reasonable value.
+    resolved_individual_timestamp_end = ind.timestamp_end or now
+    highest_date = min(now, resolved_individual_timestamp_end)
+
+    sensor_type_labels = [label.lower() for label in ind.sensor_type_ids.split(",")]
+    sensor_type_ids = [
+        MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID[label]
+        for label in sensor_type_labels
+        if label in MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID
+    ]
+    if not sensor_type_ids:
+        logger.info(f"Skip Movebank {log_reference} — no supported sensor types in '{ind.sensor_type_ids}'.")
+        return {"skipped": "no_supported_sensors"}
+
+    saved_state = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
+    try:
+        individual_state = IndividualState.parse_obj(saved_state) if saved_state else None
+    except pydantic.ValidationError:
+        logger.exception(f"Failed parsing saved state for {log_reference}; starting fresh.")
+        individual_state = None
+    if individual_state is None:
+        individual_state = IndividualState(
+            individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
+        )
+
+    # Build per-sensor cursors from state; new sensors start at the lookback window.
+    default_start = resolved_individual_timestamp_end - timedelta(hours=action_config.maximum_lookback_hours)
+    sensor_type_timestamps = {}
+    minimum_event_ids = {}
+    for sensor_type_id in sensor_type_ids:
+        sensor_state = individual_state.get_sensor_state(sensor_type_id)
+        sensor_type_timestamps[sensor_type_id] = sensor_state.latest_timestamp or default_start
+        minimum_event_ids[sensor_type_id] = (sensor_state.highest_event_id or 0) + 1
+
+    earliest_start = min(sensor_type_timestamps.values())
+    if earliest_start >= resolved_individual_timestamp_end:
+        logger.info(f"Skip Movebank {log_reference} for no new data.")
+        return {"skipped": "no_new_data"}
+
+    # Size the fetch window by event density: high-frequency individuals get a
+    # window that should hold roughly HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD events,
+    # assuming an even distribution over the individual's active range.
+    if ind.number_of_events > HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD and ind.timestamp_end:
+        total_seconds = (ind.timestamp_end - ind.timestamp_start).total_seconds()
+        batch_window_size = timedelta(
+            seconds=(HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD / ind.number_of_events) * total_seconds
+        )
+    else:
+        batch_window_size = DEFAULT_BATCH_WINDOW
+
+    logger.info(
+        f"For individual {ind.id} ({ind.nick_name}), using a window size of {batch_window_size} "
+        f"({ind.number_of_events} events on record)."
+    )
+
+    device_name = ind.nick_name or ind.local_identifier or ind.ring_id
+    auth_config = client.get_auth_config(integration)
+    total_observations_sent = 0
+    current_window_start = earliest_start
+
+    mb_client = client.MovebankClient(
+        base_url=integration.base_url,
+        username=auth_config.username,
+        password=auth_config.password.get_secret_value(),
+    )
+    async with mb_client as mb:
+        while current_window_start <= highest_date and total_observations_sent < MAXIMUM_RECORDS_PER_INDIVIDUAL:
+            end_at = min(highest_date, current_window_start + batch_window_size)
+
+            # One request per sensor type, each from its own cursor.
+            events = []
+            for sensor_type_id in sensor_type_ids:
+                sensor_start = sensor_type_timestamps[sensor_type_id]
+                if sensor_start > end_at:
+                    continue  # this sensor is already past the window
+                async for event in mb.get_individual_events_by_time(
+                    study_id=action_config.study_id,
+                    individual_id=ind.id,
+                    timestamp_start=sensor_start,
+                    timestamp_end=end_at,
+                    sensor_type_ids=[sensor_type_id],
+                    minimum_event_id=minimum_event_ids[sensor_type_id],
+                ):
+                    events.append(event)
+
+            observations = [
+                obs for event in events
+                if (obs := build_observation(event=event, device_name=device_name)) is not None
+            ]
+            for batch in chunks(observations, OBSERVATIONS_BATCH_SIZE):
+                await send_observations_to_gundi(observations=batch, integration_id=integration_id)
+
+            # Advance per-sensor cursors from what actually came back.
+            events_by_sensor = {}
+            for event in events:
+                try:
+                    events_by_sensor.setdefault(int(event.get("sensor_type_id")), []).append(event)
+                except (TypeError, ValueError):
+                    continue
+            for sensor_type_id in sensor_type_ids:
+                sensor_events = events_by_sensor.get(sensor_type_id, [])
+                sensor_timestamps = []
+                sensor_event_ids = []
+                for event in sensor_events:
+                    try:
+                        sensor_timestamps.append(parse_date(event.get("timestamp")).replace(tzinfo=timezone.utc))
+                    except Exception:
+                        pass
+                    try:
+                        sensor_event_ids.append(int(event.get("event_id")))
+                    except (TypeError, ValueError):
+                        pass
+                if sensor_timestamps:
+                    new_latest = max(sensor_timestamps)
+                    new_max_event_id = max(sensor_event_ids) if sensor_event_ids else minimum_event_ids[sensor_type_id] - 1
+                    individual_state.update_sensor_state(sensor_type_id, new_latest, new_max_event_id)
+                    sensor_type_timestamps[sensor_type_id] = new_latest
+                    minimum_event_ids[sensor_type_id] = new_max_event_id + 1
+
+            logger.info(
+                f"Processed Movebank data for {log_reference}: {len(observations)} observations, "
+                f"events by sensor: { {k: len(v) for k, v in events_by_sensor.items()} }"
+            )
+
+            if observations:
+                # Observations were sent above — only now is it safe to advance the saved cursor.
+                await state_manager.set_state(
+                    integration_id,
+                    CURSOR_STATE_ACTION_ID,
+                    json.loads(individual_state.json()),
+                    source_id=ind.id,
+                )
+            else:
+                # Nothing in this window: back off from this individual for a while.
+                await state_manager.set_state(
+                    integration_id,
+                    QUIET_STATE_ACTION_ID,
+                    {"quiet": True},
+                    source_id=ind.id,
+                    expire=QUIET_PERIOD_SECONDS,
+                )
+
+            total_observations_sent += len(observations)
+            current_window_start = current_window_start + batch_window_size
+
+    return {"observations_sent": total_observations_sent}

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -1,0 +1,63 @@
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.actions.configurations import AuthenticateConfig
+
+
+@pytest.fixture(autouse=True)
+def mock_activity_publish(mocker):
+    """Keep @activity_logger from touching PubSub in tests."""
+    mocker.patch("app.services.activity_logger.publish_event", AsyncMock(return_value=None))
+
+
+@pytest.fixture
+def integration():
+    integration = MagicMock()
+    integration.id = uuid4()
+    integration.base_url = "https://www.movebank.org"
+    integration.name = "Movebank Test"
+    return integration
+
+
+@pytest.fixture
+def mock_auth_config(mocker):
+    mocker.patch(
+        "app.actions.client.get_auth_config",
+        return_value=AuthenticateConfig(username="user", password="pass"),
+    )
+
+
+@pytest.fixture
+def mock_movebank_client(mocker):
+    """A MovebankClient instance mock usable as an async context manager."""
+    mb = MagicMock()
+    mb.__aenter__ = AsyncMock(return_value=mb)
+    mb.__aexit__ = AsyncMock(return_value=False)
+    mocker.patch("app.actions.client.MovebankClient", return_value=mb)
+    return mb
+
+
+def make_events_generator(events):
+    """Build a stand-in for the async-generator method get_individual_events_by_time."""
+    async def _gen(**kwargs):
+        for event in events:
+            yield event
+    return _gen
+
+
+INDIVIDUAL_ROW = {
+    "id": "111",
+    "local_identifier": "tag-1",
+    "nick_name": "Aquila",
+    "ring_id": "R1",
+    "sex": "f",
+    "taxon_canonical_name": "Aquila chrysaetos",
+    "timestamp_start": "2025-01-01 00:00:00.000",
+    "timestamp_end": "2026-07-01 00:00:00.000",
+    "number_of_events": "100",
+    "number_of_deployments": "1",
+    "sensor_type_ids": "gps",
+    "taxon_detail": "",
+}

--- a/app/actions/tests/test_configurations.py
+++ b/app/actions/tests/test_configurations.py
@@ -1,0 +1,48 @@
+import pytest
+from pydantic import ValidationError
+
+from app.actions.configurations import (
+    AuthenticateConfig,
+    PullEventsForIndividualConfig,
+    PullObservationsConfig,
+)
+from app.actions.core import InternalActionConfiguration, PullActionConfiguration
+
+
+INDIVIDUAL = {
+    "id": "111",
+    "local_identifier": "tag-1",
+    "nick_name": "Aquila",
+    "ring_id": "R1",
+    "sex": "f",
+    "taxon_canonical_name": "Aquila chrysaetos",
+    "timestamp_start": "2025-01-01 00:00:00.000",
+    "timestamp_end": "2026-07-01 00:00:00.000",
+    "number_of_events": 100,
+    "number_of_deployments": 1,
+    "sensor_type_ids": "gps",
+    "taxon_detail": "",
+}
+
+
+def test_pull_observations_config_requires_study_id():
+    with pytest.raises(ValidationError):
+        PullObservationsConfig()
+    config = PullObservationsConfig(study_id="12345")
+    assert config.maximum_lookback_hours == 24
+    assert isinstance(config, PullActionConfiguration)
+
+
+def test_pull_events_for_individual_config_is_internal():
+    config = PullEventsForIndividualConfig(study_id="12345", individual=INDIVIDUAL)
+    # Internal actions are not registered in the portal.
+    assert isinstance(config, InternalActionConfiguration)
+    assert config.individual.id == "111"
+    # Round-trips through dict (this is how trigger_action serializes it).
+    restored = PullEventsForIndividualConfig.parse_obj(config.dict())
+    assert restored.individual.nick_name == "Aquila"
+
+
+def test_auth_config_unchanged():
+    config = AuthenticateConfig(username="u", password="p")
+    assert config.password.get_secret_value() == "p"

--- a/app/actions/tests/test_configurations.py
+++ b/app/actions/tests/test_configurations.py
@@ -46,3 +46,5 @@ def test_pull_events_for_individual_config_is_internal():
 def test_auth_config_unchanged():
     config = AuthenticateConfig(username="u", password="p")
     assert config.password.get_secret_value() == "p"
+    from app.actions.core import ExecutableActionMixin
+    assert issubclass(AuthenticateConfig, ExecutableActionMixin)

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -230,3 +230,53 @@ async def test_pull_events_does_not_advance_cursor_when_send_fails(
             integration=integration, action_config=_sub_action_config()
         )
     assert (str(integration.id), "pull_events_for_individual", "111") not in mock_state_store
+
+
+@pytest.mark.asyncio
+async def test_pull_events_density_window_applies_without_timestamp_end(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # 60k events over ~30 days => ~2.5-day density window. With a 10-day lookback
+    # that means 4 fetch windows; the old 5-day fallback would only run 2.
+    start = (datetime.now(tz=timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%d %H:%M:%S.000")
+    gen, calls = make_counting_events_generator(0)
+    mock_movebank_client.get_individual_events_by_time = gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+
+    result = await action_pull_events_for_individual(
+        integration=integration,
+        action_config=_sub_action_config(
+            maximum_lookback_hours=240,
+            individual_overrides={
+                "timestamp_start": start,
+                "timestamp_end": "",
+                "number_of_events": "60000",
+            },
+        ),
+    )
+
+    assert result["observations_sent"] == 0
+    assert calls["count"] == 4
+
+
+@pytest.mark.asyncio
+async def test_pull_events_advances_cursor_when_all_events_are_unusable(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # Valid timestamps but no individual_id: the transform drops every record.
+    events = [{**_gps_event(100, "2026-01-01 10:00:00.000"), "individual_id": ""}]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mock_send = mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+
+    result = await action_pull_events_for_individual(
+        integration=integration, action_config=_sub_action_config()
+    )
+
+    assert result["observations_sent"] == 0
+    assert mock_send.await_count == 0
+    # Cursors advanced past the unusable events so they aren't refetched forever...
+    saved = mock_state_store.get((str(integration.id), "pull_events_for_individual", "111"))
+    assert saved is not None
+    assert IndividualState.parse_obj(saved).get_sensor_state(653).highest_event_id == 100
+    # ...and no quiet period, because the window did return events.
+    assert (str(integration.id), "pull_events_for_individual_quiet", "111") not in mock_state_store

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -45,3 +45,145 @@ async def test_pull_observations_skips_unparseable_individuals(
 
     assert result == {"individuals_found": 1, "sub_actions_triggered": 1}
     assert mock_trigger.await_count == 1
+
+
+from datetime import datetime, timedelta, timezone
+
+from app.actions.client import IndividualState
+from app.actions.configurations import PullEventsForIndividualConfig
+from app.actions.handlers import action_pull_events_for_individual
+from app.actions.tests.conftest import make_events_generator
+
+
+def _sub_action_config(**overrides):
+    individual = {**INDIVIDUAL_ROW, **overrides.pop("individual_overrides", {})}
+    return PullEventsForIndividualConfig(study_id="12345", individual=individual, **overrides)
+
+
+def _gps_event(event_id, ts):
+    return {
+        "event_id": str(event_id),
+        "timestamp": ts,
+        "location_lat": "1.5",
+        "location_long": "2.5",
+        "individual_id": "111",
+        "sensor_type_id": "653",
+    }
+
+
+@pytest.fixture
+def mock_state_store(mocker):
+    """In-memory stand-in for the module-level state_manager in handlers."""
+    store = {}
+
+    async def get_state(integration_id, action_id, source_id="no-source"):
+        return store.get((str(integration_id), action_id, source_id), {})
+
+    async def set_state(integration_id, action_id, state, source_id="no-source", expire=None):
+        store[(str(integration_id), action_id, source_id)] = state
+
+    manager = mocker.patch("app.actions.handlers.state_manager")
+    manager.get_state = AsyncMock(side_effect=get_state)
+    manager.set_state = AsyncMock(side_effect=set_state)
+    return store
+
+
+@pytest.mark.asyncio
+async def test_pull_events_sends_observations_and_updates_cursor(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    events = [_gps_event(100, "2026-01-01 10:00:00.000"), _gps_event(101, "2026-01-01 11:00:00.000")]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mock_send = mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+
+    result = await action_pull_events_for_individual(
+        integration=integration, action_config=_sub_action_config()
+    )
+
+    assert result["observations_sent"] == 2
+    assert mock_send.await_count >= 1
+    sent = [obs for call in mock_send.await_args_list for obs in call.kwargs["observations"]]
+    assert len(sent) == 2
+    assert sent[0]["source"] == "111"
+    # Cursor state persisted: GPS sensor advanced to the newest event.
+    saved = mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
+    state = IndividualState.parse_obj(saved)
+    assert state.get_sensor_state(653).highest_event_id == 101
+    assert state.get_sensor_state(653).latest_timestamp == datetime(2026, 1, 1, 11, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_pull_events_skips_individual_in_quiet_period(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    mock_state_store[(str(integration.id), "pull_events_for_individual_quiet", "111")] = {"quiet": True}
+    mock_send = mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock())
+
+    result = await action_pull_events_for_individual(
+        integration=integration, action_config=_sub_action_config()
+    )
+
+    assert result == {"skipped": "quiet_period"}
+    assert mock_send.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_pull_events_sets_quiet_period_when_window_is_empty(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    mock_movebank_client.get_individual_events_by_time = make_events_generator([])
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock())
+
+    result = await action_pull_events_for_individual(
+        integration=integration, action_config=_sub_action_config()
+    )
+
+    assert result["observations_sent"] == 0
+    quiet = mock_state_store.get((str(integration.id), "pull_events_for_individual_quiet", "111"))
+    assert quiet == {"quiet": True}
+
+
+@pytest.mark.asyncio
+async def test_pull_events_skips_individual_without_timestamp_start(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    result = await action_pull_events_for_individual(
+        integration=integration,
+        action_config=_sub_action_config(individual_overrides={"timestamp_start": ""}),
+    )
+    assert result == {"skipped": "no_timestamp_start"}
+
+
+@pytest.mark.asyncio
+async def test_pull_events_skips_when_all_sensors_are_current(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # Saved cursor is already past the individual's timestamp_end.
+    state = IndividualState(individual_id="111", study_id="12345")
+    state.update_sensor_state(653, datetime(2026, 7, 1, tzinfo=timezone.utc), 999)
+    mock_state_store[(str(integration.id), "pull_events_for_individual", "111")] = state.dict()
+
+    result = await action_pull_events_for_individual(
+        integration=integration, action_config=_sub_action_config()
+    )
+    assert result == {"skipped": "no_new_data"}
+
+
+@pytest.mark.asyncio
+async def test_pull_events_respects_max_records_cap(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # 2500 events in one window: cap stops processing at >= 2000.
+    events = [_gps_event(i, "2026-06-30 10:00:00.000") for i in range(2500)]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+
+    result = await action_pull_events_for_individual(
+        integration=integration,
+        # High-frequency path: number_of_events > 5000 shrinks the window, but a
+        # single window still returned everything here; the cap must still hold
+        # across windows.
+        action_config=_sub_action_config(individual_overrides={"number_of_events": "6000"}),
+    )
+    assert result["observations_sent"] == 2500  # first window completes...
+    # ...but no further windows ran (cap reached after the first).

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1,0 +1,47 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.actions.configurations import PullObservationsConfig
+from app.actions.handlers import action_pull_observations
+from app.actions.tests.conftest import INDIVIDUAL_ROW
+
+
+@pytest.mark.asyncio
+async def test_pull_observations_triggers_subaction_per_individual(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    second_row = {**INDIVIDUAL_ROW, "id": "222", "nick_name": "Bubo"}
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[INDIVIDUAL_ROW, second_row])
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_pull_observations(
+        integration=integration,
+        action_config=PullObservationsConfig(study_id="12345", maximum_lookback_hours=48),
+    )
+
+    assert result == {"individuals_found": 2, "sub_actions_triggered": 2}
+    assert mock_trigger.await_count == 2
+    _, kwargs = mock_trigger.await_args_list[0]
+    assert kwargs["integration_id"] == str(integration.id)
+    assert kwargs["action_id"] == "pull_events_for_individual"
+    assert kwargs["config"].study_id == "12345"
+    assert kwargs["config"].individual.id == "111"
+    assert kwargs["config"].maximum_lookback_hours == 48
+
+
+@pytest.mark.asyncio
+async def test_pull_observations_skips_unparseable_individuals(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    bad_row = {**INDIVIDUAL_ROW, "id": "333", "number_of_events": "not-a-number"}
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[INDIVIDUAL_ROW, bad_row])
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_pull_observations(
+        integration=integration,
+        action_config=PullObservationsConfig(study_id="12345"),
+    )
+
+    assert result == {"individuals_found": 1, "sub_actions_triggered": 1}
+    assert mock_trigger.await_count == 1

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -280,3 +280,23 @@ async def test_pull_events_advances_cursor_when_all_events_are_unusable(
     assert IndividualState.parse_obj(saved).get_sensor_state(653).highest_event_id == 100
     # ...and no quiet period, because the window did return events.
     assert (str(integration.id), "pull_events_for_individual_quiet", "111") not in mock_state_store
+
+
+@pytest.mark.asyncio
+async def test_pull_events_tolerates_whitespace_in_sensor_type_labels(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # "gps, accessory-measurements" (space after comma) must yield BOTH sensors:
+    # one fetch call each in the single catch-up window.
+    gen, calls = make_counting_events_generator(0)
+    mock_movebank_client.get_individual_events_by_time = gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+
+    await action_pull_events_for_individual(
+        integration=integration,
+        action_config=_sub_action_config(
+            individual_overrides={"sensor_type_ids": "gps, accessory-measurements"},
+        ),
+    )
+
+    assert calls["count"] == 2

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -169,21 +169,70 @@ async def test_pull_events_skips_when_all_sensors_are_current(
     assert result == {"skipped": "no_new_data"}
 
 
+def make_counting_events_generator(events_per_call):
+    calls = {"count": 0}
+
+    async def _gen(**kwargs):
+        base = calls["count"] * 10000
+        calls["count"] += 1
+        for i in range(events_per_call):
+            yield {
+                "event_id": str(base + i),
+                "timestamp": "2026-06-17 00:00:00.000",
+                "location_lat": "1.5",
+                "location_long": "2.5",
+                "individual_id": "111",
+                "sensor_type_id": "653",
+            }
+    return _gen, calls
+
+
 @pytest.mark.asyncio
 async def test_pull_events_respects_max_records_cap(
         mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
 ):
-    # 2500 events in one window: cap stops processing at >= 2000.
-    events = [_gps_event(i, "2026-06-30 10:00:00.000") for i in range(2500)]
-    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    # 15-day lookback with the default 5-day window => 3 windows would run,
+    # but 1200 events per window crosses the 2000 cap after window 2.
+    gen, calls = make_counting_events_generator(1200)
+    mock_movebank_client.get_individual_events_by_time = gen
     mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
 
     result = await action_pull_events_for_individual(
         integration=integration,
-        # High-frequency path: number_of_events > 5000 shrinks the window, but a
-        # single window still returned everything here; the cap must still hold
-        # across windows.
-        action_config=_sub_action_config(individual_overrides={"number_of_events": "6000"}),
+        action_config=_sub_action_config(maximum_lookback_hours=360),
     )
-    assert result["observations_sent"] == 2500  # first window completes...
-    # ...but no further windows ran (cap reached after the first).
+    assert result["observations_sent"] == 2400
+    assert calls["count"] == 2  # third window never ran
+
+
+@pytest.mark.asyncio
+async def test_pull_events_zero_range_high_frequency_individual_terminates(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # timestamp_end == timestamp_start would make the density window zero -> guard must fall back.
+    mock_movebank_client.get_individual_events_by_time = make_events_generator([])
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    result = await action_pull_events_for_individual(
+        integration=integration,
+        action_config=_sub_action_config(individual_overrides={
+            "number_of_events": "6000",
+            "timestamp_start": "2026-07-01 00:00:00.000",
+            "timestamp_end": "2026-07-01 00:00:00.000",
+        }),
+    )
+    assert result["observations_sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_pull_events_does_not_advance_cursor_when_send_fails(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    events = [_gps_event(100, "2026-01-01 10:00:00.000")]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(side_effect=Exception("gundi down")))
+
+    with pytest.raises(Exception):
+        await action_pull_events_for_individual(
+            integration=integration, action_config=_sub_action_config()
+        )
+    assert (str(integration.id), "pull_events_for_individual", "111") not in mock_state_store

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1,10 +1,12 @@
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock
 
 import pytest
 
-from app.actions.configurations import PullObservationsConfig
-from app.actions.handlers import action_pull_observations
-from app.actions.tests.conftest import INDIVIDUAL_ROW
+from app.actions.client import IndividualState
+from app.actions.configurations import PullEventsForIndividualConfig, PullObservationsConfig
+from app.actions.handlers import action_pull_events_for_individual, action_pull_observations
+from app.actions.tests.conftest import INDIVIDUAL_ROW, make_events_generator
 
 
 @pytest.mark.asyncio
@@ -45,14 +47,6 @@ async def test_pull_observations_skips_unparseable_individuals(
 
     assert result == {"individuals_found": 1, "sub_actions_triggered": 1}
     assert mock_trigger.await_count == 1
-
-
-from datetime import datetime, timedelta, timezone
-
-from app.actions.client import IndividualState
-from app.actions.configurations import PullEventsForIndividualConfig
-from app.actions.handlers import action_pull_events_for_individual
-from app.actions.tests.conftest import make_events_generator
 
 
 def _sub_action_config(**overrides):

--- a/app/actions/tests/test_models.py
+++ b/app/actions/tests/test_models.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timezone
+
+from app.actions.client import Individual, IndividualState, SensorState, generate_individuals
+
+
+INDIVIDUAL_ROW = {
+    "id": "111",
+    "local_identifier": "tag-1",
+    "nick_name": "Aquila",
+    "ring_id": "R1",
+    "sex": "f",
+    "taxon_canonical_name": "Aquila chrysaetos",
+    "timestamp_start": "2025-01-01 00:00:00.000",
+    "timestamp_end": "2026-07-01 00:00:00.000",
+    "number_of_events": "100",
+    "number_of_deployments": "1",
+    "sensor_type_ids": "gps,accessory-measurements",
+    "taxon_detail": "",
+}
+
+
+def test_individual_coerces_naive_timestamps_to_utc():
+    ind = Individual.parse_obj(INDIVIDUAL_ROW)
+    assert ind.timestamp_start == datetime(2025, 1, 1, tzinfo=timezone.utc)
+    assert ind.timestamp_end == datetime(2026, 7, 1, tzinfo=timezone.utc)
+    assert ind.number_of_events == 100
+
+
+def test_individual_tolerates_empty_timestamps():
+    row = {**INDIVIDUAL_ROW, "timestamp_start": "", "timestamp_end": ""}
+    ind = Individual.parse_obj(row)
+    assert ind.timestamp_start is None
+    assert ind.timestamp_end is None
+
+
+def test_generate_individuals_skips_bad_rows():
+    bad_row = {**INDIVIDUAL_ROW, "number_of_events": "not-a-number"}
+    result = list(generate_individuals([INDIVIDUAL_ROW, bad_row]))
+    assert len(result) == 1
+    assert result[0].id == "111"
+
+
+def test_individual_state_creates_default_sensor_state():
+    state = IndividualState(individual_id="111", study_id="12345")
+    sensor_state = state.get_sensor_state(653)
+    assert sensor_state.highest_event_id == 0
+    assert sensor_state.latest_timestamp is None
+
+
+def test_individual_state_update_and_roundtrip():
+    state = IndividualState(individual_id="111", study_id="12345")
+    ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    state.update_sensor_state(653, ts, 42)
+
+    restored = IndividualState.parse_obj(state.dict())
+    assert restored.get_sensor_state(653).highest_event_id == 42
+    assert restored.get_sensor_state(653).latest_timestamp == ts
+    # An unrelated sensor still gets a fresh default state.
+    assert restored.get_sensor_state(7842954).highest_event_id == 0

--- a/app/actions/tests/test_models.py
+++ b/app/actions/tests/test_models.py
@@ -26,6 +26,12 @@ def test_individual_coerces_naive_timestamps_to_utc():
     assert ind.number_of_events == 100
 
 
+def test_individual_normalizes_offset_aware_timestamps_to_utc():
+    row = {**INDIVIDUAL_ROW, "timestamp_start": "2025-01-01 02:00:00+02:00"}
+    ind = Individual.parse_obj(row)
+    assert ind.timestamp_start == datetime(2025, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+
 def test_individual_tolerates_empty_timestamps():
     row = {**INDIVIDUAL_ROW, "timestamp_start": "", "timestamp_end": ""}
     ind = Individual.parse_obj(row)

--- a/app/actions/tests/test_models.py
+++ b/app/actions/tests/test_models.py
@@ -33,6 +33,13 @@ def test_individual_tolerates_empty_timestamps():
     assert ind.timestamp_end is None
 
 
+def test_individual_tolerates_none_timestamps():
+    row = {**INDIVIDUAL_ROW, "timestamp_start": None, "timestamp_end": None}
+    ind = Individual.parse_obj(row)
+    assert ind.timestamp_start is None
+    assert ind.timestamp_end is None
+
+
 def test_generate_individuals_skips_bad_rows():
     bad_row = {**INDIVIDUAL_ROW, "number_of_events": "not-a-number"}
     result = list(generate_individuals([INDIVIDUAL_ROW, bad_row]))

--- a/app/actions/tests/test_transform.py
+++ b/app/actions/tests/test_transform.py
@@ -56,6 +56,14 @@ def test_build_observation_drops_events_without_individual_id():
     assert build_observation(event={**GPS_EVENT, "individual_id": ""}, device_name="A") is None
 
 
+def test_build_observation_keeps_real_zero_coordinates():
+    event = {**GPS_EVENT, "location_lat": "0.0", "location_long": "0.0"}
+    obs = build_observation(event=event, device_name="Aquila")
+    assert obs["location"] == {"lat": 0.0, "lon": 0.0}
+    # No +1ms missing-coordinate fudge for a genuine (0, 0) fix.
+    assert obs["recorded_at"] == "2026-01-01T10:00:00+00:00"
+
+
 def test_human_friendly_timedelta():
     assert human_friendly_timedelta(timedelta(days=2, hours=3, minutes=4)) == "2d, 3h, 4m"
     assert human_friendly_timedelta(timedelta(seconds=30)) == "0m"

--- a/app/actions/tests/test_transform.py
+++ b/app/actions/tests/test_transform.py
@@ -1,0 +1,66 @@
+from datetime import datetime, timedelta, timezone
+
+from app.actions.transform import build_observation, chunks, human_friendly_timedelta
+
+
+GPS_EVENT = {
+    "event_id": "100",
+    "timestamp": "2026-01-01 10:00:00.000",
+    "location_lat": "1.5",
+    "location_long": "2.5",
+    "individual_id": "111",
+    "sensor_type_id": "653",
+    "ground_speed": "3.2",
+}
+
+
+def test_build_observation_maps_gps_event():
+    obs = build_observation(event=GPS_EVENT, device_name="Aquila")
+    assert obs["source"] == "111"
+    assert obs["source_name"] == "Aquila"
+    assert obs["type"] == "tracking-device"
+    assert obs["recorded_at"] == "2026-01-01T10:00:00+00:00"
+    assert obs["location"] == {"lat": 1.5, "lon": 2.5}
+    # Everything except coordinates and timestamp lands in additional.
+    assert obs["additional"]["ground_speed"] == "3.2"
+    assert obs["additional"]["event_id"] == "100"
+    assert "location_lat" not in obs["additional"]
+    assert obs["additional"]["subject_name"] == "Aquila"
+    assert "loaded_at" in obs["additional"]
+
+
+def test_build_observation_fudges_missing_coordinates():
+    event = {**GPS_EVENT, "location_lat": "", "location_long": "", "sensor_type_id": "7842954"}
+    obs = build_observation(event=event, device_name="Aquila")
+    assert obs["location"] == {"lat": 0.0, "lon": 0.0}
+    # +1ms so it doesn't collide with a GPS record at the same instant.
+    assert obs["recorded_at"] == "2026-01-01T10:00:00.001000+00:00"
+
+
+def test_build_observation_computes_update_latency():
+    event = {**GPS_EVENT, "update_ts": "2026-01-01 12:30:00.000"}
+    obs = build_observation(event=event, device_name="Aquila")
+    assert obs["additional"]["update_latency"] == "2h, 30m"
+
+
+def test_build_observation_drops_unparseable_timestamp():
+    assert build_observation(event={**GPS_EVENT, "timestamp": "garbage"}, device_name="A") is None
+
+
+def test_build_observation_drops_future_events():
+    future = (datetime.now(tz=timezone.utc) + timedelta(days=2)).strftime("%Y-%m-%d %H:%M:%S.000")
+    assert build_observation(event={**GPS_EVENT, "timestamp": future}, device_name="A") is None
+
+
+def test_build_observation_drops_events_without_individual_id():
+    assert build_observation(event={**GPS_EVENT, "individual_id": ""}, device_name="A") is None
+
+
+def test_human_friendly_timedelta():
+    assert human_friendly_timedelta(timedelta(days=2, hours=3, minutes=4)) == "2d, 3h, 4m"
+    assert human_friendly_timedelta(timedelta(seconds=30)) == "0m"
+
+
+def test_chunks():
+    assert list(chunks([1, 2, 3, 4, 5], 2)) == [[1, 2], [3, 4], [5]]
+    assert list(chunks([], 2)) == []

--- a/app/actions/tests/test_transform.py
+++ b/app/actions/tests/test_transform.py
@@ -64,3 +64,19 @@ def test_human_friendly_timedelta():
 def test_chunks():
     assert list(chunks([1, 2, 3, 4, 5], 2)) == [[1, 2], [3, 4], [5]]
     assert list(chunks([], 2)) == []
+
+
+def test_build_observation_converts_offset_aware_timestamps_to_utc():
+    event = {**GPS_EVENT, "timestamp": "2026-01-01 10:00:00+02:00"}
+    obs = build_observation(event=event, device_name="Aquila")
+    assert obs["recorded_at"] == "2026-01-01T08:00:00+00:00"
+
+
+def test_human_friendly_timedelta_negative():
+    assert human_friendly_timedelta(timedelta(hours=-1)) == "-1h"
+    assert human_friendly_timedelta(timedelta(days=-2, hours=-3)) == "-2d, 3h"
+
+
+def test_build_observation_drops_unparseable_coordinates():
+    event = {**GPS_EVENT, "location_lat": "N/A", "location_long": "N/A"}
+    assert build_observation(event=event, device_name="Aquila") is None

--- a/app/actions/transform.py
+++ b/app/actions/transform.py
@@ -1,0 +1,79 @@
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from dateutil.parser import parse as parse_date
+
+logger = logging.getLogger(__name__)
+
+
+def human_friendly_timedelta(td: timedelta) -> str:
+    """Format a timedelta as e.g. '2d, 3h, 4m' (sub-minute becomes '0m')."""
+    days = td.days
+    hours, remainder = divmod(td.seconds, 3600)
+    minutes, _ = divmod(remainder, 60)
+
+    parts = []
+    if days > 0:
+        parts.append(f"{days}d")
+    if hours > 0:
+        parts.append(f"{hours}h")
+    if minutes > 0:
+        parts.append(f"{minutes}m")
+    return ", ".join(parts) if parts else "0m"
+
+
+def chunks(items: list, n: int):
+    for i in range(0, len(items), n):
+        yield items[i:i + n]
+
+
+def build_observation(*, event: dict, device_name: str) -> Optional[dict]:
+    """Transform one Movebank event record into a Gundi v2 observation dict.
+
+    Returns None for events that can't be used (bad timestamp, no individual_id,
+    or future-dated).
+    """
+    try:
+        recorded_at = parse_date(event.get("timestamp")).replace(tzinfo=timezone.utc)
+    except Exception:
+        logger.warning(f"unable to parse timestamp: {event.get('timestamp')}")
+        return None
+
+    # Everything except coordinates and timestamp goes to additional, so it's
+    # available for analysis in the destination.
+    additional = {k: v for k, v in event.items() if k not in ("location_long", "location_lat", "timestamp")}
+
+    if update_ts := event.get("update_ts"):
+        try:
+            updated_at = parse_date(update_ts).replace(tzinfo=timezone.utc)
+            additional["update_latency"] = human_friendly_timedelta(updated_at - recorded_at)
+        except Exception:
+            pass
+
+    individual_id = event.get("individual_id")
+    lon, lat = event.get("location_long"), event.get("location_lat")
+
+    # Records without coordinates (e.g. accessory-measurements) are stored at
+    # (0, 0) with a +1ms shift, so they don't collide with a GPS observation at
+    # the same timestamp. Revisit when observations can be updated in EarthRanger.
+    if not lon or not lat:
+        x, y = 0.0, 0.0
+        recorded_at += timedelta(milliseconds=1)
+    else:
+        x, y = float(lon), float(lat)
+
+    if not individual_id or recorded_at > datetime.now(tz=timezone.utc):
+        return None
+
+    additional["subject_name"] = device_name
+    additional["loaded_at"] = datetime.now(tz=timezone.utc).isoformat()  # fudge to avoid duplicate drop
+
+    return {
+        "source": individual_id,
+        "source_name": device_name,
+        "type": "tracking-device",
+        "recorded_at": recorded_at.isoformat(),
+        "location": {"lat": y, "lon": x},
+        "additional": additional,
+    }

--- a/app/actions/transform.py
+++ b/app/actions/transform.py
@@ -63,7 +63,9 @@ def build_observation(*, event: dict, device_name: str) -> Optional[dict]:
     # Records without coordinates (e.g. accessory-measurements) are stored at
     # (0, 0) with a +1ms shift, so they don't collide with a GPS observation at
     # the same timestamp. Revisit when observations can be updated in EarthRanger.
-    if not lon or not lat:
+    # Only genuinely missing values count as "no coordinates" — Movebank CSV
+    # rows carry coordinates as strings, and a real "0.0" must not be fudged.
+    if lon in (None, "") or lat in (None, ""):
         x, y = 0.0, 0.0
         recorded_at += timedelta(milliseconds=1)
     else:

--- a/app/actions/transform.py
+++ b/app/actions/transform.py
@@ -7,8 +7,14 @@ from dateutil.parser import parse as parse_date
 logger = logging.getLogger(__name__)
 
 
+def _ensure_utc(val: datetime) -> datetime:
+    return val.replace(tzinfo=timezone.utc) if val.tzinfo is None else val.astimezone(timezone.utc)
+
+
 def human_friendly_timedelta(td: timedelta) -> str:
     """Format a timedelta as e.g. '2d, 3h, 4m' (sub-minute becomes '0m')."""
+    if td < timedelta(0):
+        return "-" + human_friendly_timedelta(-td)
     days = td.days
     hours, remainder = divmod(td.seconds, 3600)
     minutes, _ = divmod(remainder, 60)
@@ -35,7 +41,7 @@ def build_observation(*, event: dict, device_name: str) -> Optional[dict]:
     or future-dated).
     """
     try:
-        recorded_at = parse_date(event.get("timestamp")).replace(tzinfo=timezone.utc)
+        recorded_at = _ensure_utc(parse_date(event.get("timestamp")))
     except Exception:
         logger.warning(f"unable to parse timestamp: {event.get('timestamp')}")
         return None
@@ -46,7 +52,7 @@ def build_observation(*, event: dict, device_name: str) -> Optional[dict]:
 
     if update_ts := event.get("update_ts"):
         try:
-            updated_at = parse_date(update_ts).replace(tzinfo=timezone.utc)
+            updated_at = _ensure_utc(parse_date(update_ts))
             additional["update_latency"] = human_friendly_timedelta(updated_at - recorded_at)
         except Exception:
             pass
@@ -61,7 +67,11 @@ def build_observation(*, event: dict, device_name: str) -> Optional[dict]:
         x, y = 0.0, 0.0
         recorded_at += timedelta(milliseconds=1)
     else:
-        x, y = float(lon), float(lat)
+        try:
+            x, y = float(lon), float(lat)
+        except (TypeError, ValueError):
+            logger.warning(f"unable to parse coordinates: lon={lon!r} lat={lat!r}")
+            return None
 
     if not individual_id or recorded_at > datetime.now(tz=timezone.utc):
         return None

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,1 @@
-movebank-client~=1.1.1
+movebank-client~=1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,8 @@ marshmallow==3.22.0
     # via
     #   -r requirements-base.in
     #   environs
-movebank-client==1.1.1
+    #   movebank-client
+movebank-client==1.3.1
     # via -r requirements.in
 multidict==6.0.5
     # via
@@ -136,9 +137,7 @@ redis==5.0.7
 regex==2026.6.28
     # via dateparser
 respx==0.20.2
-    # via
-    #   gundi-client-v2
-    #   movebank-client
+    # via gundi-client-v2
 six==1.17.0
     # via python-dateutil
 sniffio==1.3.1


### PR DESCRIPTION
Ports the v1 Movebank function's pull logic onto the v2 action runner.

- pull_observations (scheduled */10): lists study individuals, triggers one sub-action each
- pull_events_for_individual (internal): per-sensor-type cursors in Redis, adaptive batch
  windows for high-frequency individuals, a 2,000-records-per-run cap (checked between
  windows — a single window may overshoot before fetching stops), 1h quiet period after
  empty windows, and the production transform quirks (0,0 +1ms fudge for coordinate-less
  records, subject_name/loaded_at/update_latency in additional)
- Requires movebank-client ~=1.3.1 (accessory-measurements fetch fix; httpx range that
  co-resolves with gundi-client-v2 2.4.x)
- Observations are sent before cursors are saved, so a failed send cannot drop data
- Also fixes the template CI workflow (pip-tools 7.6.0 needs typing_extensions declared
  explicitly on py3.10) — main is currently red for the same reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)