### PR TITLE
Sync with upstream template (through July 21)

### DIFF
--- a/app/actions/core.py
+++ b/app/actions/core.py
@@ -1,9 +1,12 @@
 import importlib
 import inspect
+import logging
 from typing import Optional
 
 from pydantic import BaseModel, Field
 from app.services.utils import UISchemaModelMixin
+
+logger = logging.getLogger(__name__)
 
 
 class ActionConfiguration(UISchemaModelMixin, BaseModel):
@@ -67,8 +70,16 @@ def discover_actions(module_name, prefix):
     # Iterate through the members and filter functions by prefix
     for name, func in all_members:
         if name.startswith(prefix) and inspect.isfunction(func):
+            if func is action_title:
+                continue  # The decorator itself, often imported alongside handlers
             signature = inspect.signature(func)
             key = name[len(prefix):]  # Remove prefix
+            if "action_config" not in signature.parameters:
+                logger.warning(
+                    f"Ignoring '{name}' in '{module_name}': functions prefixed with "
+                    f"'{prefix}' must accept an 'action_config' argument to be registered as actions."
+                )
+                continue
             if (config_annotation := signature.parameters.get("action_config").annotation) != inspect._empty:
                 config_model = config_annotation
             else:

--- a/app/services/tests/test_self_registration.py
+++ b/app/services/tests/test_self_registration.py
@@ -1,6 +1,9 @@
+import sys
+import types
+
 import pytest
 from fastapi.testclient import TestClient
-from app.actions import action_title
+from app.actions import action_title, discover_actions, PullActionConfiguration
 from app.main import app
 from app.services.self_registration import register_integration_in_gundi
 from app.services.action_scheduler import crontab_schedule, CrontabSchedule
@@ -709,6 +712,51 @@ def test_action_title_decorator_stacks_with_crontab_schedule():
 
     assert action_pull_observations.action_title == "Fetch Collar Positions"
     assert action_pull_observations.crontab_schedule == CrontabSchedule.parse_obj_from_crontab("*/10 * * * *")
+
+
+def _discover_actions_in_fake_module(module):
+    module_name = "fake_handlers_module"
+    sys.modules[module_name] = module
+    try:
+        return discover_actions(module_name=module_name, prefix="action_")
+    finally:
+        del sys.modules[module_name]
+
+
+def test_discover_actions_ignores_imported_action_title_decorator():
+    # Simulates handlers.py doing `from app.actions import action_title`
+    module = types.ModuleType("fake_handlers_module")
+    module.action_title = action_title
+
+    @action_title("Fetch Collar Positions")
+    async def action_pull_observations(integration, action_config: PullActionConfiguration):
+        return {"observations_extracted": 10}
+
+    module.action_pull_observations = action_pull_observations
+
+    handlers = _discover_actions_in_fake_module(module)
+
+    assert "title" not in handlers
+    assert list(handlers.keys()) == ["pull_observations"]
+    assert handlers["pull_observations"][0] is action_pull_observations
+
+
+def test_discover_actions_ignores_functions_without_action_config():
+    module = types.ModuleType("fake_handlers_module")
+
+    def action_helper(value):
+        return value
+
+    async def action_pull_observations(integration, action_config: PullActionConfiguration):
+        return {"observations_extracted": 10}
+
+    module.action_helper = action_helper
+    module.action_pull_observations = action_pull_observations
+
+    handlers = _discover_actions_in_fake_module(module)
+
+    assert "helper" not in handlers
+    assert list(handlers.keys()) == ["pull_observations"]
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_self_registration.py
+++ b/app/services/tests/test_self_registration.py
@@ -716,11 +716,15 @@ def test_action_title_decorator_stacks_with_crontab_schedule():
 
 def _discover_actions_in_fake_module(module):
     module_name = "fake_handlers_module"
+    previous = sys.modules.get(module_name)
     sys.modules[module_name] = module
     try:
         return discover_actions(module_name=module_name, prefix="action_")
     finally:
-        del sys.modules[module_name]
+        if previous is not None:
+            sys.modules[module_name] = previous
+        else:
+            del sys.modules[module_name]
 
 
 def test_discover_actions_ignores_imported_action_title_decorator():


### PR DESCRIPTION
Merges upstream through July 21 — two batches:

**Upstream PR #80** (3 commits):
- `discover_actions` no longer crashes or mis-registers when helpers are imported into `app/actions/handlers.py`: it skips the `action_title` decorator itself (matched by identity), and skips any `action_`-prefixed function that doesn't accept an `action_config` parameter, with a warning — every valid handler must accept one
- test helper restores pre-existing `sys.modules` entries + two new self-registration tests

**Upstream PR #79** (the template-hardening batch that originated from this repo's review rounds, now round-tripped): most changes merged as already-identical; the net-new pieces are the final review round's fixes that only existed upstream —
- `/push-data` propagates execution errors again (non-2xx → PubSub redelivery; push messages carry the data, so acking failures would drop it), while malformed messages still ack-and-drop with keys-only logging + a regression test
- `_redact_url` hardening (`<no-host>` placeholder, port included)
- `get_running_loop()` in the sentinel test

**Cleanup**: dropped the legacy `IntegrationConfigurationManager` from `app/services/state.py` — dead code since the template introduced `config_manager.py`.

After this merge, the only remaining template divergence is deliberate and load-bearing: `IntegrationStateManager.set_state` accepts an `expire` (TTL) parameter that the Movebank quiet-period flag relies on (plus its test coverage). Worth upstreaming separately so future syncs are conflict-free.

Suite: 121 passed. Action discovery verified for `auth`, `pull_observations`, `pull_events_for_individual`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)