### PR TITLE
Post-merge review follow-ups from PR #11

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -5,6 +5,8 @@ from typing import Dict, Optional, Union
 import pydantic
 from dateutil.parser import parse as parse_date
 from movebank_client import MovebankClient
+# Not used in this module directly — re-exported for consumers that access them
+# through this namespace (e.g. `client.MBForbiddenError` in app/actions/handlers.py).
 from movebank_client.errors import MBClientError, MBForbiddenError
 
 from app.services.errors import ConfigurationNotFound

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -239,8 +239,12 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
                         sensor_event_ids.append(int(event.get("event_id")))
                     except (TypeError, ValueError):
                         pass
-                if sensor_timestamps:
-                    new_latest = max(sensor_timestamps)
+                if sensor_timestamps or sensor_event_ids:
+                    # Events with unparseable timestamps still advance the event-id
+                    # cursor (the client filters on minimum_event_id, so those records
+                    # aren't refetched forever); the timestamp cursor only moves when
+                    # a timestamp actually parsed.
+                    new_latest = max(sensor_timestamps) if sensor_timestamps else sensor_type_timestamps[sensor_type_id]
                     new_max_event_id = max(sensor_event_ids) if sensor_event_ids else minimum_event_ids[sensor_type_id] - 1
                     individual_state.update_sensor_state(sensor_type_id, new_latest, new_max_event_id)
                     sensor_type_timestamps[sensor_type_id] = new_latest

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -300,3 +300,24 @@ async def test_pull_events_tolerates_whitespace_in_sensor_type_labels(
     )
 
     assert calls["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_pull_events_advances_event_id_cursor_when_timestamps_unparseable(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # Garbage timestamp, valid event_id: the transform drops the record and the
+    # timestamp cursor can't move, but the event-id cursor must still advance so
+    # the same junk isn't refetched every run.
+    events = [{**_gps_event(100, "garbage-timestamp")}]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+
+    result = await action_pull_events_for_individual(
+        integration=integration, action_config=_sub_action_config()
+    )
+
+    assert result["observations_sent"] == 0
+    saved = mock_state_store.get((str(integration.id), "pull_events_for_individual", "111"))
+    assert saved is not None
+    assert IndividualState.parse_obj(saved).get_sensor_state(653).highest_event_id == 100

--- a/app/actions/tests/test_transform.py
+++ b/app/actions/tests/test_transform.py
@@ -88,3 +88,11 @@ def test_human_friendly_timedelta_negative():
 def test_build_observation_drops_unparseable_coordinates():
     event = {**GPS_EVENT, "location_lat": "N/A", "location_long": "N/A"}
     assert build_observation(event=event, device_name="Aquila") is None
+
+
+def test_chunks_rejects_non_positive_size():
+    import pytest as _pytest
+    with _pytest.raises(ValueError, match="positive integer"):
+        list(chunks([1, 2, 3], 0))
+    with _pytest.raises(ValueError, match="positive integer"):
+        list(chunks([1, 2, 3], -1))

--- a/app/actions/transform.py
+++ b/app/actions/transform.py
@@ -30,6 +30,8 @@ def human_friendly_timedelta(td: timedelta) -> str:
 
 
 def chunks(items: list, n: int):
+    if n <= 0:
+        raise ValueError(f"chunk size must be a positive integer, got {n}")
     for i in range(0, len(items), n):
         yield items[i:i + n]
 


### PR DESCRIPTION
Addresses the three review comments that landed on #11 after it merged:

- **Event-id cursor advances past unparseable-timestamp events** — previously such events could never advance any cursor and were refetched every run (with only the 1h quiet backoff limiting it). The event-id cursor now advances (the movebank-client filters on minimum_event_id), while the timestamp cursor still only moves when a timestamp parses. Regression test added.
- **chunks() validates its size argument** — n<=0 now raises a clear ValueError instead of range()'s cryptic error (n=0) or silently yielding nothing (n<0). Test added.
- **MBClientError/MBForbiddenError imports documented as re-exports** — they're consumed via `client.<name>` in handlers.py, so removing them would break auth; a comment now says so.

Suite: 120 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)