### PR TITLE
Add Movebank study backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is Gundi's integration for pulling data from Movebank Studies.
   State lives in Redis keyed by integration/action/individual.
 - **backfill** (executable) — operator-triggered historical load for a study.
   Config: `study_id`, optional `individual_ids` (whole study if empty), `start`
-  (a datetime or `"all"`), optional `backfill_max_concurrency`. Seeds a rolling
+  (a date string, e.g. `2024-01-01`, or `"all"`), optional `backfill_max_concurrency`. Seeds a rolling
   work-queue and dispatches per-individual sub-actions.
 - **backfill_events_for_individual** (internal) — self-cascading worker for one
   individual: fetches `[start, end)` in time-budgeted steps under the shared

--- a/README.md
+++ b/README.md
@@ -12,4 +12,21 @@ This is Gundi's integration for pulling data from Movebank Studies.
   a separate cursor per sensor type (GPS, accessory-measurements), batches requests in
   adaptive time windows, transforms events into observations, and sends them to Gundi.
   State lives in Redis keyed by integration/action/individual.
+- **backfill** (executable) — operator-triggered historical load for a study.
+  Config: `study_id`, optional `individual_ids` (whole study if empty), `start`
+  (a datetime or `"all"`), optional `backfill_max_concurrency`. Seeds a rolling
+  work-queue and dispatches per-individual sub-actions.
+- **backfill_events_for_individual** (internal) — self-cascading worker for one
+  individual: fetches `[start, end)` in time-budgeted steps under the shared
+  Movebank connection semaphore, sends to Gundi, and on completion hands the
+  full `(timestamp, event_id)` cursor to `pull_events_for_individual` so
+  steady-state collection continues without a gap or duplicates.
+
+### Settings
+
+- `MOVEBANK_MAX_CONNECTIONS` (default 25) — shared per-username Movebank
+  connection ceiling (Movebank allows ~31).
+- `ACCESSORY_SETTLING_HOURS` (default 12) — how far back accessory-measurements
+  queries re-read, since those records can arrive hours late.
+- `BACKFILL_MAX_CONCURRENCY` (default 8) — individuals in flight per backfill job.
 

--- a/app/actions/backfill_queue.py
+++ b/app/actions/backfill_queue.py
@@ -46,7 +46,11 @@ class BackfillJob:
         return await self.db.hincrby(self._meta, "in_flight", n)
 
     async def decr_in_flight(self) -> int:
-        return await self.db.hincrby(self._meta, "in_flight", -1)
+        value = await self.db.hincrby(self._meta, "in_flight", -1)
+        if value < 0:
+            await self.db.hset(self._meta, mapping={"in_flight": 0})
+            return 0
+        return value
 
     async def record_completion(self, observations: int) -> None:
         await self.db.hincrby(self._meta, "completed", 1)
@@ -69,5 +73,6 @@ class BackfillJob:
             "completed": int(data.get("completed", 0)),
             "observations_sent": int(data.get("observations_sent", 0)),
             "in_flight": int(data.get("in_flight", 0)),
+            "pending_remaining": await self.db.llen(self._pending),
             "range": data.get("range", ""),
         }

--- a/app/actions/backfill_queue.py
+++ b/app/actions/backfill_queue.py
@@ -5,10 +5,19 @@ import redis.asyncio as redis
 from app import settings
 
 
+# Lazily-created module-level singleton (mirrors app.services.movebank_connections'
+# _client pattern): one Redis connection shared across every BackfillJob instance
+# instead of a new one per instantiation.
+_shared_client = None
+
+
 def _client() -> redis.Redis:
-    return redis.Redis(
-        host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=settings.REDIS_STATE_DB
-    )
+    global _shared_client
+    if _shared_client is None:
+        _shared_client = redis.Redis(
+            host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=settings.REDIS_STATE_DB
+        )
+    return _shared_client
 
 
 class BackfillJob:
@@ -58,6 +67,15 @@ class BackfillJob:
 
     async def incr_attempts(self, individual_id: str) -> int:
         return await self.db.hincrby(self._meta, f"attempts.{individual_id}", 1)
+
+    async def reset_attempts(self, individual_id: str) -> None:
+        await self.db.hdel(self._meta, f"attempts.{individual_id}")
+
+    async def exists(self) -> bool:
+        """Whether this job has already been seeded (i.e. is active). Used to
+        make action_backfill's seed step idempotent against a redelivered or
+        double-clicked command hashing to the same job_id."""
+        return bool(await self.db.exists(self._meta))
 
     async def put_individual_config(self, individual_id: str, config_json: str) -> None:
         await self.db.hset(f"{self._meta}.configs", mapping={individual_id: config_json})

--- a/app/actions/backfill_queue.py
+++ b/app/actions/backfill_queue.py
@@ -51,6 +51,11 @@ class BackfillJob:
             return None
         return value.decode() if isinstance(value, bytes) else value
 
+    async def requeue(self, individual_id: str) -> None:
+        """Return a popped individual to the pending queue (e.g. when its
+        dispatch failed to publish), so it isn't lost."""
+        await self.db.rpush(self._pending, individual_id)
+
     async def incr_in_flight(self, n: int = 1) -> int:
         return await self.db.hincrby(self._meta, "in_flight", n)
 

--- a/app/actions/backfill_queue.py
+++ b/app/actions/backfill_queue.py
@@ -1,0 +1,73 @@
+from typing import List, Optional
+
+import redis.asyncio as redis
+
+from app import settings
+
+
+def _client() -> redis.Redis:
+    return redis.Redis(
+        host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=settings.REDIS_STATE_DB
+    )
+
+
+class BackfillJob:
+    """Redis-backed state for one backfill job: a pending work-queue of
+    individual IDs plus aggregate counters."""
+
+    def __init__(self, integration_id: str, job_id: str):
+        self.integration_id = str(integration_id)
+        self.job_id = job_id
+        self.db = _client()
+
+    @property
+    def _meta(self) -> str:
+        return f"backfill.{self.integration_id}.{self.job_id}.meta"
+
+    @property
+    def _pending(self) -> str:
+        return f"backfill.{self.integration_id}.{self.job_id}.pending"
+
+    async def seed(self, individual_ids: List[str], *, total: int, range_repr: str) -> None:
+        await self.db.hset(self._meta, mapping={
+            "total": total, "completed": 0, "observations_sent": 0,
+            "in_flight": 0, "range": range_repr,
+        })
+        if individual_ids:
+            await self.db.rpush(self._pending, *individual_ids)
+
+    async def next_individual(self) -> Optional[str]:
+        value = await self.db.lpop(self._pending)
+        if value is None:
+            return None
+        return value.decode() if isinstance(value, bytes) else value
+
+    async def incr_in_flight(self, n: int = 1) -> int:
+        return await self.db.hincrby(self._meta, "in_flight", n)
+
+    async def decr_in_flight(self) -> int:
+        return await self.db.hincrby(self._meta, "in_flight", -1)
+
+    async def record_completion(self, observations: int) -> None:
+        await self.db.hincrby(self._meta, "completed", 1)
+        await self.db.hincrby(self._meta, "observations_sent", observations)
+
+    async def incr_attempts(self, individual_id: str) -> int:
+        return await self.db.hincrby(self._meta, f"attempts.{individual_id}", 1)
+
+    async def is_done(self) -> bool:
+        remaining = await self.db.llen(self._pending)
+        snap = await self.snapshot()
+        return remaining == 0 and snap["in_flight"] == 0
+
+    async def snapshot(self) -> dict:
+        raw = await self.db.hgetall(self._meta)
+        data = {(k.decode() if isinstance(k, bytes) else k):
+                (v.decode() if isinstance(v, bytes) else v) for k, v in raw.items()}
+        return {
+            "total": int(data.get("total", 0)),
+            "completed": int(data.get("completed", 0)),
+            "observations_sent": int(data.get("observations_sent", 0)),
+            "in_flight": int(data.get("in_flight", 0)),
+            "range": data.get("range", ""),
+        }

--- a/app/actions/backfill_queue.py
+++ b/app/actions/backfill_queue.py
@@ -59,6 +59,13 @@ class BackfillJob:
     async def incr_attempts(self, individual_id: str) -> int:
         return await self.db.hincrby(self._meta, f"attempts.{individual_id}", 1)
 
+    async def put_individual_config(self, individual_id: str, config_json: str) -> None:
+        await self.db.hset(f"{self._meta}.configs", mapping={individual_id: config_json})
+
+    async def get_individual_config(self, individual_id: str) -> Optional[str]:
+        raw = await self.db.hget(f"{self._meta}.configs", individual_id)
+        return (raw.decode() if isinstance(raw, bytes) else raw) if raw else None
+
     async def is_done(self) -> bool:
         remaining = await self.db.llen(self._pending)
         snap = await self.snapshot()

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -6,11 +6,15 @@ from pydantic import Field, SecretStr
 from app.actions import AuthActionConfiguration, ExecutableActionMixin, PullActionConfiguration
 from app.actions.client import Individual
 from app.actions.core import GenericActionConfiguration, InternalActionConfiguration
+from app.services.utils import GlobalUISchemaOptions
 
 
 class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
     username: str
     password: SecretStr = Field(..., format="password")
+    ui_global_options = GlobalUISchemaOptions(
+        order=["username", "password"],
+    )
 
 
 class PullObservationsConfig(PullActionConfiguration):

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 
 from pydantic import Field, SecretStr
 
@@ -45,7 +45,7 @@ class BackfillConfig(GenericActionConfiguration, ExecutableActionMixin):
         title="Individual IDs",
         description="Leave empty to backfill the whole study, or list specific individual IDs.",
     )
-    start: Union[datetime, str] = Field(
+    start: Union[datetime, Literal["all"]] = Field(
         "all",
         title="Start",
         description="Earliest datetime to backfill from, or 'all' to fetch from each individual's earliest record.",
@@ -54,6 +54,7 @@ class BackfillConfig(GenericActionConfiguration, ExecutableActionMixin):
         None,
         title="Max Concurrency",
         description="Individuals processed in parallel. Defaults to the service's BACKFILL_MAX_CONCURRENCY.",
+        ge=1,
     )
 
 

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -1,8 +1,11 @@
+from datetime import datetime
+from typing import List, Optional, Union
+
 from pydantic import Field, SecretStr
 
 from app.actions import AuthActionConfiguration, ExecutableActionMixin, PullActionConfiguration
 from app.actions.client import Individual
-from app.actions.core import InternalActionConfiguration
+from app.actions.core import GenericActionConfiguration, InternalActionConfiguration
 
 
 class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
@@ -31,3 +34,32 @@ class PullEventsForIndividualConfig(InternalActionConfiguration):
     study_id: str
     individual: Individual
     maximum_lookback_hours: int = 24
+
+
+class BackfillConfig(GenericActionConfiguration, ExecutableActionMixin):
+    """Operator-triggered study backfill. Executable, NOT scheduled — it must
+    not subclass PullActionConfiguration."""
+    study_id: str = Field(..., title="Movebank Study ID")
+    individual_ids: Optional[List[str]] = Field(
+        None,
+        title="Individual IDs",
+        description="Leave empty to backfill the whole study, or list specific individual IDs.",
+    )
+    start: Union[datetime, str] = Field(
+        "all",
+        title="Start",
+        description="Earliest datetime to backfill from, or 'all' to fetch from each individual's earliest record.",
+    )
+    backfill_max_concurrency: Optional[int] = Field(
+        None,
+        title="Max Concurrency",
+        description="Individuals processed in parallel. Defaults to the service's BACKFILL_MAX_CONCURRENCY.",
+    )
+
+
+class BackfillEventsForIndividualConfig(InternalActionConfiguration):
+    study_id: str
+    individual: Individual
+    job_id: str
+    start: datetime
+    end: datetime

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -1,7 +1,8 @@
 from datetime import datetime
-from typing import List, Literal, Optional, Union
+from typing import List, Optional
 
-from pydantic import Field, SecretStr
+from dateutil.parser import parse as parse_date
+from pydantic import Field, SecretStr, validator
 
 from app.actions import AuthActionConfiguration, ExecutableActionMixin, PullActionConfiguration
 from app.actions.client import Individual
@@ -40,19 +41,20 @@ class PullEventsForIndividualConfig(InternalActionConfiguration):
     maximum_lookback_hours: int = 24
 
 
+# Executable, NOT scheduled — must not subclass PullActionConfiguration
+# (that would register it for type-wide scheduling).
 class BackfillConfig(GenericActionConfiguration, ExecutableActionMixin):
-    """Operator-triggered study backfill. Executable, NOT scheduled — it must
-    not subclass PullActionConfiguration."""
+    """Back-fill historical Movebank data for a study."""
     study_id: str = Field(..., title="Movebank Study ID")
     individual_ids: Optional[List[str]] = Field(
         None,
         title="Individual IDs",
         description="Leave empty to backfill the whole study, or list specific individual IDs.",
     )
-    start: Union[datetime, Literal["all"]] = Field(
+    start: str = Field(
         "all",
         title="Start",
-        description="Earliest datetime to backfill from, or 'all' to fetch from each individual's earliest record.",
+        description="A start date (e.g. 2024-01-01) or 'all' to fetch from each individual's earliest record.",
     )
     backfill_max_concurrency: Optional[int] = Field(
         None,
@@ -60,6 +62,21 @@ class BackfillConfig(GenericActionConfiguration, ExecutableActionMixin):
         description="Individuals processed in parallel. Defaults to the service's BACKFILL_MAX_CONCURRENCY.",
         ge=1,
     )
+    ui_global_options = GlobalUISchemaOptions(
+        order=["study_id", "individual_ids", "start", "backfill_max_concurrency"],
+    )
+
+    @validator("start")
+    def _validate_start(cls, value):
+        # A real date or the literal "all" — never let a typo silently become
+        # full-history "all".
+        if value.strip().lower() == "all":
+            return "all"
+        try:
+            parse_date(value)
+        except (ValueError, OverflowError, TypeError):
+            raise ValueError("start must be a date (e.g. 2024-01-01) or 'all'")
+        return value
 
 
 class BackfillEventsForIndividualConfig(InternalActionConfiguration):

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -548,16 +548,22 @@ async def _finalize_backfill_individual(integration_id, job, ind, action_config,
                 existing_state.update_sensor_state(stid, new_ts, new_event_id)
         await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
                                       json.loads(existing_state.json()), source_id=ind.id)
-        # Success path only: the watermark has served its purpose (merged
-        # into the pull cursor above) and would otherwise never be cleaned up.
-        # NOT deleted on the abandon path (state is None) — that watermark
-        # must survive so a later re-run of this individual resumes instead
-        # of restarting from scratch.
-        await state_manager.delete_state(
-            integration_id, BACKFILL_WATERMARK_ACTION_ID, source_id=f"{action_config.job_id}.{ind.id}"
-        )
     await job.record_completion(observations)
     await job.decr_in_flight()
+
+    if state is not None:
+        # Best-effort watermark cleanup, AFTER the job counters are updated:
+        # the watermark has served its purpose (merged into the pull cursor
+        # above), but a Redis hiccup here must not leave in_flight un-decremented
+        # and the job stuck. A leftover watermark is harmless (this individual
+        # is done; a re-run is refused by the idempotent-seed guard). NOT deleted
+        # on the abandon path (state is None) so a re-run resumes from it.
+        try:
+            await state_manager.delete_state(
+                integration_id, BACKFILL_WATERMARK_ACTION_ID, source_id=f"{action_config.job_id}.{ind.id}"
+            )
+        except Exception as exc:
+            logger.warning(f"Backfill {action_config.job_id}/{ind.id}: watermark cleanup failed (harmless): {exc}")
 
     if await job.is_done():
         snap = await job.snapshot()

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -502,47 +502,54 @@ async def action_backfill_events_for_individual(integration, action_config: Back
     ind = action_config.individual
     integration_id = str(integration.id)
     job = BackfillJob(integration_id, action_config.job_id)
+    watermark_source = f"{action_config.job_id}.{ind.id}"
+    log_reference = f"job:{action_config.job_id},individual:{ind.id}"
+
+    sensor_type_ids = _supported_sensor_type_ids(ind)
+    if not sensor_type_ids:
+        return await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
+
+    saved = await state_manager.get_state(integration_id, BACKFILL_WATERMARK_ACTION_ID, source_id=watermark_source)
+    state = IndividualState.parse_obj(saved) if saved else IndividualState(
+        individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
+    )
+    sensor_type_timestamps, minimum_event_ids = {}, {}
+    for stid in sensor_type_ids:
+        ss = state.get_sensor_state(stid)
+        sensor_type_timestamps[stid] = ss.latest_timestamp or action_config.start
+        minimum_event_ids[stid] = (ss.highest_event_id or 0) + 1
+
+    # The scan position is a DURABLE floor, persisted every window regardless
+    # of whether events came back. Windows are anchored to it (below), not to
+    # the per-sensor event cursor above — otherwise a sensor that returns
+    # nothing for the whole range would never move its own cursor, and a
+    # re-trigger after a budget-exhausted step would recompute `current` from
+    # that unmoved cursor and rescan the same empty span forever (livelock).
+    persisted_scan_from = None
+    if saved and saved.get("scan_from"):
+        try:
+            persisted_scan_from = _ensure_utc(parse_date(saved["scan_from"]))
+        except Exception:
+            persisted_scan_from = None
+
+    auth_config = client.get_auth_config(integration)
+    deadline = time.monotonic() + 0.8 * settings.MAX_ACTION_EXECUTION_TIME
+    window = DEFAULT_BATCH_WINDOW
+    observations_sent = 0
+    current = persisted_scan_from if persisted_scan_from is not None else min(sensor_type_timestamps.values())
+
+    mb_client = client.MovebankClient(
+        base_url=integration.base_url, username=auth_config.username,
+        password=auth_config.password.get_secret_value(),
+    )
+    # Only the fetch/send cascade (and its pre-finalize watermark bookkeeping) is
+    # guarded here: NoConnectionSlot and Movebank/transform errors originate in
+    # this loop. The completion decision below (continue vs. finalize) must stay
+    # OUTSIDE the try — if finalize's own post-processing (dispatch-next PubSub
+    # publish, is_done, snapshot) raised while wrapped in this try, an already
+    # -completed individual would be retried/abandoned and _finalize would run a
+    # second time, double-counting record_completion/decr_in_flight.
     try:
-        watermark_source = f"{action_config.job_id}.{ind.id}"
-        log_reference = f"job:{action_config.job_id},individual:{ind.id}"
-
-        sensor_type_ids = _supported_sensor_type_ids(ind)
-        if not sensor_type_ids:
-            return await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
-
-        saved = await state_manager.get_state(integration_id, BACKFILL_WATERMARK_ACTION_ID, source_id=watermark_source)
-        state = IndividualState.parse_obj(saved) if saved else IndividualState(
-            individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
-        )
-        sensor_type_timestamps, minimum_event_ids = {}, {}
-        for stid in sensor_type_ids:
-            ss = state.get_sensor_state(stid)
-            sensor_type_timestamps[stid] = ss.latest_timestamp or action_config.start
-            minimum_event_ids[stid] = (ss.highest_event_id or 0) + 1
-
-        # The scan position is a DURABLE floor, persisted every window regardless
-        # of whether events came back. Windows are anchored to it (below), not to
-        # the per-sensor event cursor above — otherwise a sensor that returns
-        # nothing for the whole range would never move its own cursor, and a
-        # re-trigger after a budget-exhausted step would recompute `current` from
-        # that unmoved cursor and rescan the same empty span forever (livelock).
-        persisted_scan_from = None
-        if saved and saved.get("scan_from"):
-            try:
-                persisted_scan_from = _ensure_utc(parse_date(saved["scan_from"]))
-            except Exception:
-                persisted_scan_from = None
-
-        auth_config = client.get_auth_config(integration)
-        deadline = time.monotonic() + 0.8 * settings.MAX_ACTION_EXECUTION_TIME
-        window = DEFAULT_BATCH_WINDOW
-        observations_sent = 0
-        current = persisted_scan_from if persisted_scan_from is not None else min(sensor_type_timestamps.values())
-
-        mb_client = client.MovebankClient(
-            base_url=integration.base_url, username=auth_config.username,
-            password=auth_config.password.get_secret_value(),
-        )
         async with mb_client as mb:
             while current < action_config.end and time.monotonic() < deadline:
                 end_at = min(action_config.end, current + window)
@@ -574,18 +581,6 @@ async def action_backfill_events_for_individual(integration, action_config: Back
                 blob["scan_from"] = current.isoformat()
                 await state_manager.set_state(integration_id, BACKFILL_WATERMARK_ACTION_ID,
                                               blob, source_id=watermark_source)
-
-        if current < action_config.end:
-            # Budget exhausted mid-range: continue THIS individual on the next step.
-            await trigger_action(
-                integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=action_config,
-            )
-            logger.info(f"Backfill {log_reference} continued at {current.isoformat()} ({observations_sent} obs this step)")
-            return {"status": "continued", "observations_sent": observations_sent}
-
-        return await _finalize_backfill_individual(
-            integration_id, job, ind, action_config, observations=observations_sent, state=state
-        )
     except NoConnectionSlot:
         # No connection slot available: re-trigger THIS individual (same in-flight
         # unit continues) rather than losing the step or double-counting in-flight.
@@ -601,3 +596,15 @@ async def action_backfill_events_for_individual(integration, action_config: Back
         logger.warning(f"Backfill {action_config.job_id}/{ind.id}: abandoned after {attempts} attempts: {exc}")
         result = await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
         return {"status": "abandoned", **{k: v for k, v in result.items() if k != "status"}}
+
+    if current < action_config.end:
+        # Budget exhausted mid-range: continue THIS individual on the next step.
+        await trigger_action(
+            integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=action_config,
+        )
+        logger.info(f"Backfill {log_reference} continued at {current.isoformat()} ({observations_sent} obs this step)")
+        return {"status": "continued", "observations_sent": observations_sent}
+
+    return await _finalize_backfill_individual(
+        integration_id, job, ind, action_config, observations=observations_sent, state=state
+    )

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -7,12 +7,14 @@ from dateutil.parser import parse as parse_date
 from movebank_client import MovebankClient
 
 import app.actions.client as client
+from app import settings
 from app.actions.client import IndividualState, generate_individuals
 from app.actions.configurations import AuthenticateConfig, PullObservationsConfig, PullEventsForIndividualConfig
 from app.actions.transform import _ensure_utc, build_observation, chunks
 from app.services.action_scheduler import crontab_schedule, trigger_action
 from app.services.activity_logger import activity_logger
 from app.services.gundi import send_observations_to_gundi
+from app.services.movebank_connections import movebank_slot, NoConnectionSlot
 from app.services.state import IntegrationStateManager
 
 
@@ -31,6 +33,14 @@ OBSERVATIONS_BATCH_SIZE = 200
 
 CURSOR_STATE_ACTION_ID = "pull_events_for_individual"
 QUIET_STATE_ACTION_ID = "pull_events_for_individual_quiet"
+
+
+def _query_start_for_sensor(sensor_type_id: int, sensor_start: datetime) -> datetime:
+    """Accessory-measurements can arrive hours late, so its query re-reads back
+    ACCESSORY_SETTLING_HOURS; GPS is prompt and uses its exact cursor."""
+    if sensor_type_id == MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID["accessory-measurements"]:
+        return sensor_start - timedelta(hours=settings.ACCESSORY_SETTLING_HOURS)
+    return sensor_start
 
 
 async def action_auth(integration, action_config: AuthenticateConfig):
@@ -199,16 +209,18 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
                 sensor_start = sensor_type_timestamps[sensor_type_id]
                 if sensor_start > end_at:
                     continue  # this sensor is already past the window
+                query_start = _query_start_for_sensor(sensor_type_id, sensor_start)
                 sensor_events = []
-                async for event in mb.get_individual_events_by_time(
-                    study_id=action_config.study_id,
-                    individual_id=ind.id,
-                    timestamp_start=sensor_start,
-                    timestamp_end=end_at,
-                    sensor_type_ids=[sensor_type_id],
-                    minimum_event_id=minimum_event_ids[sensor_type_id],
-                ):
-                    sensor_events.append(event)
+                async with movebank_slot(auth_config.username):
+                    async for event in mb.get_individual_events_by_time(
+                        study_id=action_config.study_id,
+                        individual_id=ind.id,
+                        timestamp_start=query_start,
+                        timestamp_end=end_at,
+                        sensor_type_ids=[sensor_type_id],
+                        minimum_event_id=minimum_event_ids[sensor_type_id],
+                    ):
+                        sensor_events.append(event)
                 events_by_sensor[sensor_type_id] = sensor_events
                 events.extend(sensor_events)
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -10,6 +10,7 @@ from dateutil.parser import parse as parse_date
 from movebank_client import MovebankClient
 
 import app.actions.client as client
+from app.actions.core import action_title
 from app import settings
 from app.actions.backfill_queue import BackfillJob
 from app.actions.client import IndividualState, generate_individuals
@@ -129,6 +130,7 @@ def _advance_watermarks(state, events, sensor_type_ids, sensor_type_timestamps, 
             minimum_event_ids[stid] = new_max + 1
 
 
+@action_title("(1) Movebank Credentials")
 async def action_auth(integration, action_config: AuthenticateConfig):
     logger.info(
         f"Executing auth action with integration {integration} and action_config {action_config}..."
@@ -156,6 +158,7 @@ async def action_auth(integration, action_config: AuthenticateConfig):
             return {"valid_credentials": False}
 
 
+@action_title("(2) Read Movebank Data")
 @activity_logger()
 @crontab_schedule("*/10 * * * *")  # same cadence as the v1 cronjob
 async def action_pull_observations(integration, action_config: PullObservationsConfig):
@@ -348,10 +351,16 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
 
 def _resolve_start(start, ind) -> datetime:
     """A concrete datetime for this individual: the operator's date, or for
-    'all' the individual's earliest record (falling back to the lookback floor)."""
+    'all' the individual's earliest record (falling back to the lookback floor).
+
+    `start` is the validated config value — the literal "all", or a date string
+    (BackfillConfig.start). A datetime is also accepted for programmatic callers.
+    """
     if isinstance(start, datetime):
         return start
-    # start == "all"
+    if isinstance(start, str) and start.strip().lower() != "all":
+        return _ensure_utc(parse_date(start))
+    # "all"
     if ind.timestamp_start:
         return ind.timestamp_start
     return datetime.now(tz=timezone.utc) - timedelta(days=3650)  # ~10y floor
@@ -390,6 +399,7 @@ async def _seed_pull_cursor_at_end(integration_id: str, study_id: str, ind, end:
     await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID, json.loads(state.json()), source_id=ind.id)
 
 
+@action_title("(3) Backfill Movebank Data for a Study")
 @activity_logger()
 async def action_backfill(integration, action_config: BackfillConfig):
     integration_id = str(integration.id)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -84,7 +84,8 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         password=auth_config.password.get_secret_value(),
     )
     async with mb_client as mb:
-        individual_rows = await mb.get_individuals_by_study(study_id=action_config.study_id)
+        async with movebank_slot(auth_config.username):
+            individual_rows = await mb.get_individuals_by_study(study_id=action_config.study_id)
 
     individuals = list(generate_individuals(individual_rows))
     logger.info(f"{len(individuals)} individuals found for study {action_config.study_id}")

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import logging
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -54,6 +55,38 @@ def _query_start_for_sensor(sensor_type_id: int, sensor_start: datetime) -> date
     if sensor_type_id == MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID["accessory-measurements"]:
         return sensor_start - timedelta(hours=settings.ACCESSORY_SETTLING_HOURS)
     return sensor_start
+
+
+def _advance_watermarks(state, events, sensor_type_ids, sensor_type_timestamps, minimum_event_ids):
+    """Per-sensor cursor advancement shared by the steady-state pull and the
+    backfill sub-action: regroups a flat event list by each event's own
+    sensor_type_id field, then advances the timestamp/event-id cursor for each
+    sensor type from what actually came back (event-id cursor still advances
+    on unparseable timestamps so junk records aren't refetched forever)."""
+    events_by_sensor = {}
+    for e in events:
+        try:
+            events_by_sensor.setdefault(int(e.get("sensor_type_id")), []).append(e)
+        except (TypeError, ValueError):
+            continue
+    for stid in sensor_type_ids:
+        se = events_by_sensor.get(stid, [])
+        stamps, ids = [], []
+        for e in se:
+            try:
+                stamps.append(_ensure_utc(parse_date(e.get("timestamp"))))
+            except Exception:
+                pass
+            try:
+                ids.append(int(e.get("event_id")))
+            except (TypeError, ValueError):
+                pass
+        if stamps or ids:
+            new_latest = max(stamps) if stamps else sensor_type_timestamps[stid]
+            new_max = max(ids) if ids else minimum_event_ids[stid] - 1
+            state.update_sensor_state(stid, new_latest, new_max)
+            sensor_type_timestamps[stid] = new_latest
+            minimum_event_ids[stid] = new_max + 1
 
 
 async def action_auth(integration, action_config: AuthenticateConfig):
@@ -252,29 +285,7 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
                 await send_observations_to_gundi(observations=batch, integration_id=integration_id)
 
             # Advance per-sensor cursors from what actually came back.
-            for sensor_type_id in sensor_type_ids:
-                sensor_events = events_by_sensor.get(sensor_type_id, [])
-                sensor_timestamps = []
-                sensor_event_ids = []
-                for event in sensor_events:
-                    try:
-                        sensor_timestamps.append(_ensure_utc(parse_date(event.get("timestamp"))))
-                    except Exception:
-                        pass
-                    try:
-                        sensor_event_ids.append(int(event.get("event_id")))
-                    except (TypeError, ValueError):
-                        pass
-                if sensor_timestamps or sensor_event_ids:
-                    # Events with unparseable timestamps still advance the event-id
-                    # cursor (the client filters on minimum_event_id, so those records
-                    # aren't refetched forever); the timestamp cursor only moves when
-                    # a timestamp actually parsed.
-                    new_latest = max(sensor_timestamps) if sensor_timestamps else sensor_type_timestamps[sensor_type_id]
-                    new_max_event_id = max(sensor_event_ids) if sensor_event_ids else minimum_event_ids[sensor_type_id] - 1
-                    individual_state.update_sensor_state(sensor_type_id, new_latest, new_max_event_id)
-                    sensor_type_timestamps[sensor_type_id] = new_latest
-                    minimum_event_ids[sensor_type_id] = new_max_event_id + 1
+            _advance_watermarks(individual_state, events, sensor_type_ids, sensor_type_timestamps, minimum_event_ids)
 
             logger.info(
                 f"Processed Movebank data for {log_reference}: {len(observations)} observations, "
@@ -362,24 +373,147 @@ async def action_backfill(integration, action_config: BackfillConfig):
 
     logger.info(f"Backfill {job_id} for study {action_config.study_id}: {len(queued)} individuals, range {range_repr}")
 
+    # Store each queued individual's sub-action config up front, so the rolling
+    # dispatch (here and from the sub-action's finalize step) always reads
+    # from the same place regardless of when an individual is popped.
+    for i in queued:
+        start_dt, end_dt = ranges[i.id]
+        await job.put_individual_config(
+            i.id,
+            BackfillEventsForIndividualConfig(
+                study_id=action_config.study_id, individual=i,
+                job_id=job_id, start=start_dt, end=end_dt,
+            ).json(),
+        )
+
     k = action_config.backfill_max_concurrency or settings.BACKFILL_MAX_CONCURRENCY
-    by_id = {i.id: i for i in queued}
     dispatched = 0
     while dispatched < k:
         next_id = await job.next_individual()
         if next_id is None:
             break
-        ind = by_id[next_id]
-        start_dt, end_dt = ranges[next_id]
-        await job.incr_in_flight()
-        await trigger_action(
-            integration_id=integration_id,
-            action_id=BACKFILL_ACTION_ID,
-            config=BackfillEventsForIndividualConfig(
-                study_id=action_config.study_id, individual=ind,
-                job_id=job_id, start=start_dt, end=end_dt,
-            ),
-        )
+        await _dispatch_backfill_individual(integration_id, job, next_id)
         dispatched += 1
 
     return {"job_id": job_id, "individuals": len(queued), "dispatched": dispatched}
+
+
+async def _dispatch_backfill_individual(integration_id, job, individual_id):
+    """Read the stored per-individual config and trigger the sub-action.
+
+    Single dispatch path used both for the backfill action's first wave and
+    for the sub-action's rolling dispatch-next on completion.
+    """
+    blob = await job.get_individual_config(individual_id)
+    if blob is None:
+        logger.warning(f"Backfill {job.job_id}: no stored config for individual {individual_id}; skipping")
+        return
+    cfg = BackfillEventsForIndividualConfig.parse_raw(blob)
+    await job.incr_in_flight()
+    await trigger_action(integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=cfg)
+
+
+async def _finalize_backfill_individual(integration_id, job, ind, action_config, *, observations, state=None):
+    # Hand off the FULL cursor (timestamp + highest event id per sensor) to the
+    # steady-state pull, so the pull's event-id filter absorbs the accessory
+    # settling re-read at the boundary without re-emitting backfilled events.
+    if state is not None:
+        existing = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
+        if not existing:
+            await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
+                                          json.loads(state.json()), source_id=ind.id)
+    await job.record_completion(observations)
+    await job.decr_in_flight()
+
+    if await job.is_done():
+        snap = await job.snapshot()
+        logger.info(f"Backfill {action_config.job_id} finished: {snap['completed']}/{snap['total']} "
+                    f"individuals, {snap['observations_sent']} observations")
+    else:
+        if await state_manager.set_if_absent(
+            integration_id, f"backfill_progress.{action_config.job_id}", ttl_seconds=BACKFILL_PROGRESS_THROTTLE_SECONDS
+        ):
+            snap = await job.snapshot()
+            logger.info(f"Backfill {action_config.job_id} progress: {snap['completed']}/{snap['total']} "
+                        f"individuals, ~{snap['observations_sent']} observations")
+        next_id = await job.next_individual()
+        if next_id is not None:
+            await _dispatch_backfill_individual(integration_id, job, next_id)
+
+    return {"status": "completed", "observations_sent": observations}
+
+
+@activity_logger()
+async def action_backfill_events_for_individual(integration, action_config: BackfillEventsForIndividualConfig):
+    ind = action_config.individual
+    integration_id = str(integration.id)
+    job = BackfillJob(integration_id, action_config.job_id)
+    watermark_source = f"{action_config.job_id}.{ind.id}"
+    log_reference = f"job:{action_config.job_id},individual:{ind.id}"
+
+    sensor_type_labels = [label.strip().lower() for label in ind.sensor_type_ids.split(",")]
+    sensor_type_ids = [
+        MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID[label]
+        for label in sensor_type_labels
+        if label in MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID
+    ]
+    if not sensor_type_ids:
+        return await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
+
+    saved = await state_manager.get_state(integration_id, BACKFILL_WATERMARK_ACTION_ID, source_id=watermark_source)
+    state = IndividualState.parse_obj(saved) if saved else IndividualState(
+        individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
+    )
+    sensor_type_timestamps, minimum_event_ids = {}, {}
+    for stid in sensor_type_ids:
+        ss = state.get_sensor_state(stid)
+        sensor_type_timestamps[stid] = ss.latest_timestamp or action_config.start
+        minimum_event_ids[stid] = (ss.highest_event_id or 0) + 1
+
+    auth_config = client.get_auth_config(integration)
+    deadline = time.monotonic() + 0.8 * settings.MAX_ACTION_EXECUTION_TIME
+    window = DEFAULT_BATCH_WINDOW
+    observations_sent = 0
+    current = min(sensor_type_timestamps.values())
+
+    mb_client = client.MovebankClient(
+        base_url=integration.base_url, username=auth_config.username,
+        password=auth_config.password.get_secret_value(),
+    )
+    async with mb_client as mb:
+        while current < action_config.end and time.monotonic() < deadline:
+            end_at = min(action_config.end, current + window)
+            events = []
+            for stid in sensor_type_ids:
+                sensor_start = sensor_type_timestamps[stid]
+                if sensor_start > end_at:
+                    continue
+                query_start = _query_start_for_sensor(stid, sensor_start)
+                async with movebank_slot(auth_config.username):
+                    async for event in mb.get_individual_events_by_time(
+                        study_id=action_config.study_id, individual_id=ind.id,
+                        timestamp_start=query_start, timestamp_end=end_at,
+                        sensor_type_ids=[stid], minimum_event_id=minimum_event_ids[stid],
+                    ):
+                        events.append(event)
+
+            device_name = ind.nick_name or ind.local_identifier or ind.ring_id
+            observations = [o for e in events if (o := build_observation(event=e, device_name=device_name)) is not None]
+            for batch in chunks(observations, OBSERVATIONS_BATCH_SIZE):
+                await send_observations_to_gundi(observations=batch, integration_id=integration_id)
+
+            _advance_watermarks(state, events, sensor_type_ids, sensor_type_timestamps, minimum_event_ids)
+            observations_sent += len(observations)
+            current = current + window
+            await state_manager.set_state(integration_id, BACKFILL_WATERMARK_ACTION_ID,
+                                          json.loads(state.json()), source_id=watermark_source)
+
+    if current < action_config.end:
+        # Budget exhausted mid-range: continue THIS individual on the next step.
+        await trigger_action(
+            integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=action_config,
+        )
+        logger.info(f"Backfill {log_reference} continued at {current.isoformat()} ({observations_sent} obs this step)")
+        return {"status": "continued", "observations_sent": observations_sent}
+
+    return await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=observations_sent, state=state)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -48,14 +48,42 @@ BACKFILL_ACTION_ID = "backfill_events_for_individual"
 BACKFILL_WATERMARK_ACTION_ID = "backfill_watermark"
 BACKFILL_PROGRESS_THROTTLE_SECONDS = 300
 BACKFILL_MAX_ATTEMPTS = 5
+# Per-step backstop for the backfill cascade: once a single invocation's
+# observations reach this, it stops taking more windows, persists its scan
+# position, and re-triggers — bounding how long one PubSub-ack'd invocation
+# can run even if window sizing (below) underestimates event density.
+MAX_RECORDS_PER_BACKFILL_STEP = 10000
 
 
-def _query_start_for_sensor(sensor_type_id: int, sensor_start: datetime) -> datetime:
+def _query_start_for_sensor(sensor_type_id: int, sensor_start: datetime, minimum_event_id: int) -> datetime:
     """Accessory-measurements can arrive hours late, so its query re-reads back
-    ACCESSORY_SETTLING_HOURS; GPS is prompt and uses its exact cursor."""
-    if sensor_type_id == MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID["accessory-measurements"]:
+    ACCESSORY_SETTLING_HOURS — but only once there's a real prior cursor for
+    this sensor (minimum_event_id > 1, i.e. at least one event already
+    recorded). Widening a freshly-seeded cursor (minimum_event_id == 1, no
+    prior events — e.g. right after _seed_pull_cursor_at_end) would re-read
+    [T-settling, T) with minimum_event_id=1 and re-emit duplicates of
+    everything already sent in that span. GPS is prompt and always uses its
+    exact cursor."""
+    if (sensor_type_id == MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID["accessory-measurements"]
+            and minimum_event_id > 1):
         return sensor_start - timedelta(hours=settings.ACCESSORY_SETTLING_HOURS)
     return sensor_start
+
+
+def _compute_batch_window(number_of_events, span_seconds) -> timedelta:
+    """Shared window-sizing logic for the steady-state pull and backfill:
+    high-frequency individuals get a window sized to hold roughly
+    HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD events over the given span, assuming
+    an even distribution; falls back to DEFAULT_BATCH_WINDOW otherwise, or
+    when the computed window would be non-positive (which would never
+    advance the scan position and spin forever)."""
+    if (number_of_events or 0) > HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD:
+        window = timedelta(seconds=(HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD / number_of_events) * span_seconds)
+    else:
+        window = DEFAULT_BATCH_WINDOW
+    if window <= timedelta(0):
+        window = DEFAULT_BATCH_WINDOW
+    return window
 
 
 def _supported_sensor_type_ids(ind) -> list:
@@ -217,22 +245,14 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
         logger.info(f"Skip Movebank {log_reference} for no new data.")
         return {"skipped": "no_new_data"}
 
-    # Size the fetch window by event density: high-frequency individuals get a
-    # window that should hold roughly HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD events,
-    # assuming an even distribution over the individual's active range.
-    if (ind.number_of_events or 0) > HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD:
-        # resolved_individual_timestamp_end falls back to now when the individual
-        # omits timestamp_end, so density sizing works for those individuals too.
-        total_seconds = (resolved_individual_timestamp_end - ind.timestamp_start).total_seconds()
-        batch_window_size = timedelta(
-            seconds=(HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD / ind.number_of_events) * total_seconds
-        )
-    else:
-        batch_window_size = DEFAULT_BATCH_WINDOW
-    if batch_window_size <= timedelta(0):
-        # A zero/negative window (timestamp_end <= timestamp_start) would never
-        # advance current_window_start and spin the fetch loop forever.
-        batch_window_size = DEFAULT_BATCH_WINDOW
+    # Size the fetch window by event density (shared with backfill via
+    # _compute_batch_window): high-frequency individuals get a window that
+    # should hold roughly HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD events, assuming
+    # an even distribution over the individual's active range.
+    # resolved_individual_timestamp_end falls back to now when the individual
+    # omits timestamp_end, so density sizing works for those individuals too.
+    total_seconds = (resolved_individual_timestamp_end - ind.timestamp_start).total_seconds()
+    batch_window_size = _compute_batch_window(ind.number_of_events, total_seconds)
 
     logger.info(
         f"For individual {ind.id} ({ind.nick_name}), using a window size of {batch_window_size} "
@@ -264,7 +284,7 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
                 sensor_start = sensor_type_timestamps[sensor_type_id]
                 if sensor_start > end_at:
                     continue  # this sensor is already past the window
-                query_start = _query_start_for_sensor(sensor_type_id, sensor_start)
+                query_start = _query_start_for_sensor(sensor_type_id, sensor_start, minimum_event_ids[sensor_type_id])
                 sensor_events = []
                 async with movebank_slot(auth_config.username):
                     async for event in mb.get_individual_events_by_time(
@@ -393,6 +413,34 @@ async def action_backfill(integration, action_config: BackfillConfig):
     job_id = "job-" + hashlib.sha256(job_seed.encode()).hexdigest()[:12]
     job = BackfillJob(integration_id, job_id)
 
+    # Idempotent seed: a redelivered/double-clicked backfill command hashes to
+    # the SAME job_id. If that job is already active, re-seeding would
+    # re-zero its counters and re-RPUSH individuals that are already in
+    # flight or already dispatched — double-dispatching them. Bail out early.
+    if await job.exists():
+        logger.info(f"Backfill {job_id}: job already active, skipping re-seed")
+        return {"job_id": job_id, "already_active": True}
+
+    # Backfill is for INITIAL load only: an individual that already has a
+    # steady-state pull cursor is skipped entirely (not queued) — filling
+    # history behind an existing cursor isn't supported yet, and attempting it
+    # would duplicate data the pull has already collected.
+    candidates = []
+    skipped_existing = []
+    for i in individuals:
+        saved = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=i.id)
+        if saved:
+            skipped_existing.append(i.id)
+        else:
+            candidates.append(i)
+    if skipped_existing:
+        logger.warning(
+            f"Backfill {job_id}: skipped {len(skipped_existing)} individuals that already have "
+            "collection history (backfill is for initial load; filling history behind an "
+            "existing cursor is not yet supported)"
+        )
+    individuals = candidates
+
     ranges = {}
     had_cursor = {}
     for i in individuals:
@@ -434,22 +482,36 @@ async def action_backfill(integration, action_config: BackfillConfig):
         await _dispatch_backfill_individual(integration_id, job, next_id)
         dispatched += 1
 
-    return {"job_id": job_id, "individuals": len(queued), "dispatched": dispatched}
+    return {
+        "job_id": job_id, "individuals": len(queued), "dispatched": dispatched,
+        "skipped_existing": len(skipped_existing),
+    }
 
 
 async def _dispatch_backfill_individual(integration_id, job, individual_id):
     """Read the stored per-individual config and trigger the sub-action.
 
     Single dispatch path used both for the backfill action's first wave and
-    for the sub-action's rolling dispatch-next on completion.
+    for the sub-action's rolling dispatch-next on completion. If an
+    individual's config is missing (e.g. a lost/evicted Redis entry), this
+    advances to the next pending individual instead of stalling the driver
+    chain — bounded by the queue's length at call time so a fully-missing
+    configs hash can't loop forever.
     """
-    blob = await job.get_individual_config(individual_id)
-    if blob is None:
+    snap = await job.snapshot()
+    max_attempts = snap["pending_remaining"] + 1  # +1 for the individual_id passed in
+    for _ in range(max_attempts):
+        if individual_id is None:
+            return
+        blob = await job.get_individual_config(individual_id)
+        if blob is not None:
+            cfg = BackfillEventsForIndividualConfig.parse_raw(blob)
+            await job.incr_in_flight()
+            await trigger_action(integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=cfg)
+            return
         logger.warning(f"Backfill {job.job_id}: no stored config for individual {individual_id}; skipping")
-        return
-    cfg = BackfillEventsForIndividualConfig.parse_raw(blob)
-    await job.incr_in_flight()
-    await trigger_action(integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=cfg)
+        individual_id = await job.next_individual()
+    logger.warning(f"Backfill {job.job_id}: exhausted pending queue looking for a valid config to dispatch")
 
 
 async def _finalize_backfill_individual(integration_id, job, ind, action_config, *, observations, state=None):
@@ -476,6 +538,14 @@ async def _finalize_backfill_individual(integration_id, job, ind, action_config,
                 existing_state.update_sensor_state(stid, new_ts, new_event_id)
         await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
                                       json.loads(existing_state.json()), source_id=ind.id)
+        # Success path only: the watermark has served its purpose (merged
+        # into the pull cursor above) and would otherwise never be cleaned up.
+        # NOT deleted on the abandon path (state is None) — that watermark
+        # must survive so a later re-run of this individual resumes instead
+        # of restarting from scratch.
+        await state_manager.delete_state(
+            integration_id, BACKFILL_WATERMARK_ACTION_ID, source_id=f"{action_config.job_id}.{ind.id}"
+        )
     await job.record_completion(observations)
     await job.decr_in_flight()
 
@@ -534,7 +604,8 @@ async def action_backfill_events_for_individual(integration, action_config: Back
 
     auth_config = client.get_auth_config(integration)
     deadline = time.monotonic() + 0.8 * settings.MAX_ACTION_EXECUTION_TIME
-    window = DEFAULT_BATCH_WINDOW
+    span_seconds = (action_config.end - action_config.start).total_seconds()
+    window = _compute_batch_window(ind.number_of_events, span_seconds)
     observations_sent = 0
     current = persisted_scan_from if persisted_scan_from is not None else min(sensor_type_timestamps.values())
 
@@ -556,8 +627,18 @@ async def action_backfill_events_for_individual(integration, action_config: Back
                 # All sensors sweep the same [current, end_at) window together —
                 # anchored to the scan floor, not each sensor's own cursor.
                 events = []
+                window_interrupted = False
                 for stid in sensor_type_ids:
-                    query_start = _query_start_for_sensor(stid, current)
+                    # Check BETWEEN per-sensor fetches too, not just between
+                    # windows: a dense window's fetches alone can exceed the
+                    # budget, and an uncaught CancelledError from a killed
+                    # task would leak in_flight and leave a permanent data gap
+                    # (main.py's PubSub endpoint always acks — there is no
+                    # redelivery to recover a killed step).
+                    if time.monotonic() >= deadline:
+                        window_interrupted = True
+                        break
+                    query_start = _query_start_for_sensor(stid, current, minimum_event_ids[stid])
                     async with movebank_slot(auth_config.username):
                         async for event in mb.get_individual_events_by_time(
                             study_id=action_config.study_id, individual_id=ind.id,
@@ -573,7 +654,12 @@ async def action_backfill_events_for_individual(integration, action_config: Back
 
                 _advance_watermarks(state, events, sensor_type_ids, sensor_type_timestamps, minimum_event_ids)
                 observations_sent += len(observations)
-                current = current + window
+                if not window_interrupted:
+                    # Only advance past this window if EVERY sensor was fetched
+                    # for it; an interrupted window is retried in full next
+                    # step (safe: per-sensor minimum_event_id already advanced
+                    # for whichever sensors DID get fetched, so no duplicates).
+                    current = current + window
 
                 # Persist the scan floor together with the sensor states in a
                 # single call, every window, regardless of whether events came back.
@@ -581,6 +667,13 @@ async def action_backfill_events_for_individual(integration, action_config: Back
                 blob["scan_from"] = current.isoformat()
                 await state_manager.set_state(integration_id, BACKFILL_WATERMARK_ACTION_ID,
                                               blob, source_id=watermark_source)
+
+                # Per-step backstop: a dense window can return far more than
+                # expected even with density-based sizing. Stop taking more
+                # windows once this step's total crosses the cap, rather than
+                # risking the invocation running past its execution budget.
+                if window_interrupted or observations_sent >= MAX_RECORDS_PER_BACKFILL_STEP:
+                    break
     except NoConnectionSlot:
         # No connection slot available: re-trigger THIS individual (same in-flight
         # unit continues) rather than losing the step or double-counting in-flight.
@@ -596,6 +689,12 @@ async def action_backfill_events_for_individual(integration, action_config: Back
         logger.warning(f"Backfill {action_config.job_id}/{ind.id}: abandoned after {attempts} attempts: {exc}")
         result = await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
         return {"status": "abandoned", **{k: v for k, v in result.items() if k != "status"}}
+
+    # A successful step (fetch/send loop completed without raising) resets the
+    # attempts counter — so transient errors spread thinly across a long
+    # cascade don't accumulate toward abandonment; only CONSECUTIVE failures
+    # count against BACKFILL_MAX_ATTEMPTS.
+    await job.reset_attempts(ind.id)
 
     if current < action_config.end:
         # Budget exhausted mid-range: continue THIS individual on the next step.

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -47,6 +47,7 @@ QUIET_STATE_ACTION_ID = "pull_events_for_individual_quiet"
 BACKFILL_ACTION_ID = "backfill_events_for_individual"
 BACKFILL_WATERMARK_ACTION_ID = "backfill_watermark"
 BACKFILL_PROGRESS_THROTTLE_SECONDS = 300
+BACKFILL_MAX_ATTEMPTS = 5
 
 
 def _query_start_for_sensor(sensor_type_id: int, sensor_start: datetime) -> datetime:
@@ -501,84 +502,102 @@ async def action_backfill_events_for_individual(integration, action_config: Back
     ind = action_config.individual
     integration_id = str(integration.id)
     job = BackfillJob(integration_id, action_config.job_id)
-    watermark_source = f"{action_config.job_id}.{ind.id}"
-    log_reference = f"job:{action_config.job_id},individual:{ind.id}"
+    try:
+        watermark_source = f"{action_config.job_id}.{ind.id}"
+        log_reference = f"job:{action_config.job_id},individual:{ind.id}"
 
-    sensor_type_ids = _supported_sensor_type_ids(ind)
-    if not sensor_type_ids:
-        return await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
+        sensor_type_ids = _supported_sensor_type_ids(ind)
+        if not sensor_type_ids:
+            return await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
 
-    saved = await state_manager.get_state(integration_id, BACKFILL_WATERMARK_ACTION_ID, source_id=watermark_source)
-    state = IndividualState.parse_obj(saved) if saved else IndividualState(
-        individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
-    )
-    sensor_type_timestamps, minimum_event_ids = {}, {}
-    for stid in sensor_type_ids:
-        ss = state.get_sensor_state(stid)
-        sensor_type_timestamps[stid] = ss.latest_timestamp or action_config.start
-        minimum_event_ids[stid] = (ss.highest_event_id or 0) + 1
-
-    # The scan position is a DURABLE floor, persisted every window regardless
-    # of whether events came back. Windows are anchored to it (below), not to
-    # the per-sensor event cursor above — otherwise a sensor that returns
-    # nothing for the whole range would never move its own cursor, and a
-    # re-trigger after a budget-exhausted step would recompute `current` from
-    # that unmoved cursor and rescan the same empty span forever (livelock).
-    persisted_scan_from = None
-    if saved and saved.get("scan_from"):
-        try:
-            persisted_scan_from = _ensure_utc(parse_date(saved["scan_from"]))
-        except Exception:
-            persisted_scan_from = None
-
-    auth_config = client.get_auth_config(integration)
-    deadline = time.monotonic() + 0.8 * settings.MAX_ACTION_EXECUTION_TIME
-    window = DEFAULT_BATCH_WINDOW
-    observations_sent = 0
-    current = persisted_scan_from if persisted_scan_from is not None else min(sensor_type_timestamps.values())
-
-    mb_client = client.MovebankClient(
-        base_url=integration.base_url, username=auth_config.username,
-        password=auth_config.password.get_secret_value(),
-    )
-    async with mb_client as mb:
-        while current < action_config.end and time.monotonic() < deadline:
-            end_at = min(action_config.end, current + window)
-            # All sensors sweep the same [current, end_at) window together —
-            # anchored to the scan floor, not each sensor's own cursor.
-            events = []
-            for stid in sensor_type_ids:
-                query_start = _query_start_for_sensor(stid, current)
-                async with movebank_slot(auth_config.username):
-                    async for event in mb.get_individual_events_by_time(
-                        study_id=action_config.study_id, individual_id=ind.id,
-                        timestamp_start=query_start, timestamp_end=end_at,
-                        sensor_type_ids=[stid], minimum_event_id=minimum_event_ids[stid],
-                    ):
-                        events.append(event)
-
-            device_name = ind.nick_name or ind.local_identifier or ind.ring_id
-            observations = [o for e in events if (o := build_observation(event=e, device_name=device_name)) is not None]
-            for batch in chunks(observations, OBSERVATIONS_BATCH_SIZE):
-                await send_observations_to_gundi(observations=batch, integration_id=integration_id)
-
-            _advance_watermarks(state, events, sensor_type_ids, sensor_type_timestamps, minimum_event_ids)
-            observations_sent += len(observations)
-            current = current + window
-
-            # Persist the scan floor together with the sensor states in a
-            # single call, every window, regardless of whether events came back.
-            blob = json.loads(state.json())
-            blob["scan_from"] = current.isoformat()
-            await state_manager.set_state(integration_id, BACKFILL_WATERMARK_ACTION_ID,
-                                          blob, source_id=watermark_source)
-
-    if current < action_config.end:
-        # Budget exhausted mid-range: continue THIS individual on the next step.
-        await trigger_action(
-            integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=action_config,
+        saved = await state_manager.get_state(integration_id, BACKFILL_WATERMARK_ACTION_ID, source_id=watermark_source)
+        state = IndividualState.parse_obj(saved) if saved else IndividualState(
+            individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
         )
-        logger.info(f"Backfill {log_reference} continued at {current.isoformat()} ({observations_sent} obs this step)")
-        return {"status": "continued", "observations_sent": observations_sent}
+        sensor_type_timestamps, minimum_event_ids = {}, {}
+        for stid in sensor_type_ids:
+            ss = state.get_sensor_state(stid)
+            sensor_type_timestamps[stid] = ss.latest_timestamp or action_config.start
+            minimum_event_ids[stid] = (ss.highest_event_id or 0) + 1
 
-    return await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=observations_sent, state=state)
+        # The scan position is a DURABLE floor, persisted every window regardless
+        # of whether events came back. Windows are anchored to it (below), not to
+        # the per-sensor event cursor above — otherwise a sensor that returns
+        # nothing for the whole range would never move its own cursor, and a
+        # re-trigger after a budget-exhausted step would recompute `current` from
+        # that unmoved cursor and rescan the same empty span forever (livelock).
+        persisted_scan_from = None
+        if saved and saved.get("scan_from"):
+            try:
+                persisted_scan_from = _ensure_utc(parse_date(saved["scan_from"]))
+            except Exception:
+                persisted_scan_from = None
+
+        auth_config = client.get_auth_config(integration)
+        deadline = time.monotonic() + 0.8 * settings.MAX_ACTION_EXECUTION_TIME
+        window = DEFAULT_BATCH_WINDOW
+        observations_sent = 0
+        current = persisted_scan_from if persisted_scan_from is not None else min(sensor_type_timestamps.values())
+
+        mb_client = client.MovebankClient(
+            base_url=integration.base_url, username=auth_config.username,
+            password=auth_config.password.get_secret_value(),
+        )
+        async with mb_client as mb:
+            while current < action_config.end and time.monotonic() < deadline:
+                end_at = min(action_config.end, current + window)
+                # All sensors sweep the same [current, end_at) window together —
+                # anchored to the scan floor, not each sensor's own cursor.
+                events = []
+                for stid in sensor_type_ids:
+                    query_start = _query_start_for_sensor(stid, current)
+                    async with movebank_slot(auth_config.username):
+                        async for event in mb.get_individual_events_by_time(
+                            study_id=action_config.study_id, individual_id=ind.id,
+                            timestamp_start=query_start, timestamp_end=end_at,
+                            sensor_type_ids=[stid], minimum_event_id=minimum_event_ids[stid],
+                        ):
+                            events.append(event)
+
+                device_name = ind.nick_name or ind.local_identifier or ind.ring_id
+                observations = [o for e in events if (o := build_observation(event=e, device_name=device_name)) is not None]
+                for batch in chunks(observations, OBSERVATIONS_BATCH_SIZE):
+                    await send_observations_to_gundi(observations=batch, integration_id=integration_id)
+
+                _advance_watermarks(state, events, sensor_type_ids, sensor_type_timestamps, minimum_event_ids)
+                observations_sent += len(observations)
+                current = current + window
+
+                # Persist the scan floor together with the sensor states in a
+                # single call, every window, regardless of whether events came back.
+                blob = json.loads(state.json())
+                blob["scan_from"] = current.isoformat()
+                await state_manager.set_state(integration_id, BACKFILL_WATERMARK_ACTION_ID,
+                                              blob, source_id=watermark_source)
+
+        if current < action_config.end:
+            # Budget exhausted mid-range: continue THIS individual on the next step.
+            await trigger_action(
+                integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=action_config,
+            )
+            logger.info(f"Backfill {log_reference} continued at {current.isoformat()} ({observations_sent} obs this step)")
+            return {"status": "continued", "observations_sent": observations_sent}
+
+        return await _finalize_backfill_individual(
+            integration_id, job, ind, action_config, observations=observations_sent, state=state
+        )
+    except NoConnectionSlot:
+        # No connection slot available: re-trigger THIS individual (same in-flight
+        # unit continues) rather than losing the step or double-counting in-flight.
+        await trigger_action(integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=action_config)
+        logger.info(f"Backfill {action_config.job_id}/{ind.id}: no connection slot, backing off")
+        return {"status": "backoff"}
+    except Exception as exc:
+        attempts = await job.incr_attempts(ind.id)
+        if attempts <= BACKFILL_MAX_ATTEMPTS:
+            await trigger_action(integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=action_config)
+            logger.info(f"Backfill {action_config.job_id}/{ind.id}: attempt {attempts} failed ({exc}); retrying")
+            return {"status": "retry", "attempts": attempts}
+        logger.warning(f"Backfill {action_config.job_id}/{ind.id}: abandoned after {attempts} attempts: {exc}")
+        result = await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
+        return {"status": "abandoned", **{k: v for k, v in result.items() if k != "status"}}

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -1,6 +1,8 @@
+import hashlib
 import json
 import logging
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 import pydantic
 from dateutil.parser import parse as parse_date
@@ -8,8 +10,15 @@ from movebank_client import MovebankClient
 
 import app.actions.client as client
 from app import settings
+from app.actions.backfill_queue import BackfillJob
 from app.actions.client import IndividualState, generate_individuals
-from app.actions.configurations import AuthenticateConfig, PullObservationsConfig, PullEventsForIndividualConfig
+from app.actions.configurations import (
+    AuthenticateConfig,
+    BackfillConfig,
+    BackfillEventsForIndividualConfig,
+    PullObservationsConfig,
+    PullEventsForIndividualConfig,
+)
 from app.actions.transform import _ensure_utc, build_observation, chunks
 from app.services.action_scheduler import crontab_schedule, trigger_action
 from app.services.activity_logger import activity_logger
@@ -33,6 +42,10 @@ OBSERVATIONS_BATCH_SIZE = 200
 
 CURSOR_STATE_ACTION_ID = "pull_events_for_individual"
 QUIET_STATE_ACTION_ID = "pull_events_for_individual_quiet"
+
+BACKFILL_ACTION_ID = "backfill_events_for_individual"
+BACKFILL_WATERMARK_ACTION_ID = "backfill_watermark"
+BACKFILL_PROGRESS_THROTTLE_SECONDS = 300
 
 
 def _query_start_for_sensor(sensor_type_id: int, sensor_start: datetime) -> datetime:
@@ -292,3 +305,80 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
             current_window_start = current_window_start + batch_window_size
 
     return {"observations_sent": total_observations_sent}
+
+
+def _resolve_start(start, ind) -> datetime:
+    """A concrete datetime for this individual: the operator's date, or for
+    'all' the individual's earliest record (falling back to the lookback floor)."""
+    if isinstance(start, datetime):
+        return start
+    # start == "all"
+    if ind.timestamp_start:
+        return ind.timestamp_start
+    return datetime.now(tz=timezone.utc) - timedelta(days=3650)  # ~10y floor
+
+
+async def _resolve_end(integration_id: str, ind, now: datetime) -> datetime:
+    """Freeze the boundary where backfill meets the steady-state pull: the
+    individual's existing pull cursor if any, else now (and the pull is seeded
+    to now by the individual sub-action on completion)."""
+    saved = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
+    if saved:
+        state = IndividualState.parse_obj(saved)
+        stamps = [s.latest_timestamp for s in state.sensor_states.values() if s.latest_timestamp]
+        if stamps:
+            return min(stamps)
+    return now
+
+
+@activity_logger()
+async def action_backfill(integration, action_config: BackfillConfig):
+    integration_id = str(integration.id)
+    now = datetime.now(tz=timezone.utc)
+    auth_config = client.get_auth_config(integration)
+    mb_client = client.MovebankClient(
+        base_url=integration.base_url,
+        username=auth_config.username,
+        password=auth_config.password.get_secret_value(),
+    )
+    async with mb_client as mb:
+        rows = await mb.get_individuals_by_study(study_id=action_config.study_id)
+    individuals = list(generate_individuals(rows))
+    if action_config.individual_ids:
+        wanted = set(action_config.individual_ids)
+        individuals = [i for i in individuals if i.id in wanted]
+
+    # Deterministic job id: a redelivered backfill command resumes the same job.
+    job_seed = f"{action_config.study_id}:{sorted(i.id for i in individuals)}:{action_config.start}"
+    job_id = "job-" + hashlib.sha256(job_seed.encode()).hexdigest()[:12]
+    job = BackfillJob(integration_id, job_id)
+
+    ranges = {i.id: (_resolve_start(action_config.start, i), await _resolve_end(integration_id, i, now)) for i in individuals}
+    # Only individuals with a non-empty range are worth queuing.
+    queued = [i for i in individuals if ranges[i.id][0] < ranges[i.id][1]]
+    range_repr = f"[{action_config.start} .. {now.isoformat()})"
+    await job.seed([i.id for i in queued], total=len(queued), range_repr=range_repr)
+
+    logger.info(f"Backfill {job_id} for study {action_config.study_id}: {len(queued)} individuals, range {range_repr}")
+
+    k = action_config.backfill_max_concurrency or settings.BACKFILL_MAX_CONCURRENCY
+    by_id = {i.id: i for i in queued}
+    dispatched = 0
+    while dispatched < k:
+        next_id = await job.next_individual()
+        if next_id is None:
+            break
+        ind = by_id[next_id]
+        start_dt, end_dt = ranges[next_id]
+        await job.incr_in_flight()
+        await trigger_action(
+            integration_id=integration_id,
+            action_id=BACKFILL_ACTION_ID,
+            config=BackfillEventsForIndividualConfig(
+                study_id=action_config.study_id, individual=ind,
+                job_id=job_id, start=start_dt, end=end_dt,
+            ),
+        )
+        dispatched += 1
+
+    return {"job_id": job_id, "individuals": len(queued), "dispatched": dispatched}

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -561,7 +561,18 @@ async def _dispatch_backfill_individual(integration_id, job, individual_id):
         if blob is not None:
             cfg = BackfillEventsForIndividualConfig.parse_raw(blob)
             await job.incr_in_flight()
-            await trigger_action(integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=cfg)
+            try:
+                await trigger_action(integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=cfg)
+            except Exception:
+                # Publish failed (e.g. commands topic unset, transient PubSub
+                # error). Roll back the increment and return the individual to
+                # the queue so it isn't lost — an inflated in_flight would also
+                # block the resume path (which keys on in_flight == 0). Re-raise
+                # so a persistent failure stays visible; state is now consistent
+                # for a later resume.
+                await job.decr_in_flight()
+                await job.requeue(individual_id)
+                raise
             return
         logger.warning(f"Backfill {job.job_id}: no stored config for individual {individual_id}; skipping")
         individual_id = await job.next_individual()

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -282,13 +282,13 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
             # to a single sensor_type_id, Movebank reliably echoes that same id
             # back on every event it returns.
             events = []
-            events_by_sensor = {}
+            sensor_event_counts = {}  # per-sensor counts for logging + the fetched-any check
             for sensor_type_id in sensor_type_ids:
                 sensor_start = sensor_type_timestamps[sensor_type_id]
                 if sensor_start > end_at:
                     continue  # this sensor is already past the window
                 query_start = _query_start_for_sensor(sensor_type_id, sensor_start, minimum_event_ids[sensor_type_id])
-                sensor_events = []
+                count = 0
                 async with movebank_slot(auth_config.username):
                     async for event in mb.get_individual_events_by_time(
                         study_id=action_config.study_id,
@@ -298,11 +298,11 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
                         sensor_type_ids=[sensor_type_id],
                         minimum_event_id=minimum_event_ids[sensor_type_id],
                     ):
-                        sensor_events.append(event)
-                events_by_sensor[sensor_type_id] = sensor_events
-                events.extend(sensor_events)
+                        events.append(event)  # single combined list; no per-sensor copy
+                        count += 1
+                sensor_event_counts[sensor_type_id] = count
 
-            if not events_by_sensor:
+            if not sensor_event_counts:
                 # Every sensor was already past this window: advance without
                 # touching the quiet flag or the saved cursor (v1 behavior).
                 current_window_start = current_window_start + batch_window_size
@@ -320,7 +320,7 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
 
             logger.info(
                 f"Processed Movebank data for {log_reference}: {len(observations)} observations, "
-                f"events by sensor: { {k: len(v) for k, v in events_by_sensor.items()} }"
+                f"events by sensor: {sensor_event_counts}"
             )
 
             if events:
@@ -428,6 +428,27 @@ async def action_backfill(integration, action_config: BackfillConfig):
     # re-zero its counters and re-RPUSH individuals that are already in
     # flight or already dispatched — double-dispatching them. Bail out early.
     if await job.exists():
+        snap = await job.snapshot()
+        if snap["in_flight"] == 0 and snap["pending_remaining"] > 0:
+            # A prior invocation seeded the job (meta + pending) but crashed
+            # before/while dispatching — nothing is in flight yet work is still
+            # queued. There's no PubSub redelivery to restart it, so a re-run
+            # would otherwise return already_active forever. Resume instead:
+            # dispatch up to K from the pending queue (configs were stored at
+            # seed time; _dispatch_backfill_individual skips any that are missing).
+            logger.info(
+                f"Backfill {job_id}: resuming stalled job "
+                f"({snap['pending_remaining']} pending, none in flight)"
+            )
+            k = action_config.backfill_max_concurrency or settings.BACKFILL_MAX_CONCURRENCY
+            dispatched = 0
+            while dispatched < k:
+                next_id = await job.next_individual()
+                if next_id is None:
+                    break
+                await _dispatch_backfill_individual(integration_id, job, next_id)
+                dispatched += 1
+            return {"job_id": job_id, "resumed": True, "dispatched": dispatched}
         logger.info(f"Backfill {job_id}: job already active, skipping re-seed")
         return {"job_id": job_id, "already_active": True}
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -57,6 +57,17 @@ def _query_start_for_sensor(sensor_type_id: int, sensor_start: datetime) -> date
     return sensor_start
 
 
+def _supported_sensor_type_ids(ind) -> list:
+    """Movebank sensor-type labels this individual reports, mapped to the
+    numeric sensor_type_ids this integration knows how to handle."""
+    labels = [label.strip().lower() for label in ind.sensor_type_ids.split(",")]
+    return [
+        MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID[label]
+        for label in labels
+        if label in MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID
+    ]
+
+
 def _advance_watermarks(state, events, sensor_type_ids, sensor_type_timestamps, minimum_event_ids):
     """Per-sensor cursor advancement shared by the steady-state pull and the
     backfill sub-action: regroups a flat event list by each event's own
@@ -175,12 +186,7 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
     resolved_individual_timestamp_end = ind.timestamp_end or now
     highest_date = min(now, resolved_individual_timestamp_end)
 
-    sensor_type_labels = [label.strip().lower() for label in ind.sensor_type_ids.split(",")]
-    sensor_type_ids = [
-        MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID[label]
-        for label in sensor_type_labels
-        if label in MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID
-    ]
+    sensor_type_ids = _supported_sensor_type_ids(ind)
     if not sensor_type_ids:
         logger.info(f"Skip Movebank {log_reference} — no supported sensor types in '{ind.sensor_type_ids}'.")
         return {"skipped": "no_supported_sensors"}
@@ -246,10 +252,11 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
         while current_window_start <= highest_date and total_observations_sent < MAXIMUM_RECORDS_PER_INDIVIDUAL:
             end_at = min(highest_date, current_window_start + batch_window_size)
 
-            # One request per sensor type, each from its own cursor. Events are
-            # grouped by the requesting sensor (each fetch is already scoped to
-            # one sensor type), so cursor advancement doesn't depend on Movebank
-            # echoing sensor_type_id back on every event.
+            # One request per sensor type, each from its own cursor.
+            # _advance_watermarks regroups the combined events by each event's
+            # own sensor_type_id field; since every request here already filters
+            # to a single sensor_type_id, Movebank reliably echoes that same id
+            # back on every event it returns.
             events = []
             events_by_sensor = {}
             for sensor_type_id in sensor_type_ids:
@@ -329,17 +336,37 @@ def _resolve_start(start, ind) -> datetime:
     return datetime.now(tz=timezone.utc) - timedelta(days=3650)  # ~10y floor
 
 
-async def _resolve_end(integration_id: str, ind, now: datetime) -> datetime:
+async def _resolve_end(integration_id: str, ind, now: datetime) -> tuple:
     """Freeze the boundary where backfill meets the steady-state pull: the
-    individual's existing pull cursor if any, else now (and the pull is seeded
-    to now by the individual sub-action on completion)."""
+    individual's existing pull cursor if any, else now.
+
+    Returns (end, had_existing_cursor). When there was no existing cursor,
+    action_backfill claims it itself (seeds it to `now`, see
+    _seed_pull_cursor_at_end) so a concurrent steady-state pull run can't
+    compute its own lookback-based start and reach back into the range
+    backfill is about to cover.
+    """
     saved = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
     if saved:
         state = IndividualState.parse_obj(saved)
         stamps = [s.latest_timestamp for s in state.sensor_states.values() if s.latest_timestamp]
         if stamps:
-            return min(stamps)
-    return now
+            return min(stamps), True
+    return now, False
+
+
+async def _seed_pull_cursor_at_end(integration_id: str, study_id: str, ind, end: datetime) -> None:
+    """Claim [end, +inf) for the steady-state pull cursor before backfill starts.
+
+    Without this, an individual with no existing pull cursor lets the */10
+    pull compute its own lookback-based start and reach back into the range
+    backfill is about to cover — shipping duplicate observations, since
+    loaded_at doesn't dedup them.
+    """
+    state = IndividualState(individual_id=ind.id, study_id=study_id, local_identifier=ind.local_identifier)
+    for stid in _supported_sensor_type_ids(ind):
+        state.update_sensor_state(stid, end, 0)
+    await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID, json.loads(state.json()), source_id=ind.id)
 
 
 @activity_logger()
@@ -365,7 +392,13 @@ async def action_backfill(integration, action_config: BackfillConfig):
     job_id = "job-" + hashlib.sha256(job_seed.encode()).hexdigest()[:12]
     job = BackfillJob(integration_id, job_id)
 
-    ranges = {i.id: (_resolve_start(action_config.start, i), await _resolve_end(integration_id, i, now)) for i in individuals}
+    ranges = {}
+    had_cursor = {}
+    for i in individuals:
+        end_dt, cursor_existed = await _resolve_end(integration_id, i, now)
+        ranges[i.id] = (_resolve_start(action_config.start, i), end_dt)
+        had_cursor[i.id] = cursor_existed
+
     # Only individuals with a non-empty range are worth queuing.
     queued = [i for i in individuals if ranges[i.id][0] < ranges[i.id][1]]
     range_repr = f"[{action_config.start} .. {now.isoformat()})"
@@ -375,9 +408,14 @@ async def action_backfill(integration, action_config: BackfillConfig):
 
     # Store each queued individual's sub-action config up front, so the rolling
     # dispatch (here and from the sub-action's finalize step) always reads
-    # from the same place regardless of when an individual is popped.
+    # from the same place regardless of when an individual is popped. Also
+    # claim the pull cursor's floor for individuals that don't have one yet,
+    # so a concurrent steady-state pull run can't reach back into the range
+    # backfill is about to cover (see _seed_pull_cursor_at_end).
     for i in queued:
         start_dt, end_dt = ranges[i.id]
+        if not had_cursor[i.id]:
+            await _seed_pull_cursor_at_end(integration_id, action_config.study_id, i, end_dt)
         await job.put_individual_config(
             i.id,
             BackfillEventsForIndividualConfig(
@@ -414,14 +452,29 @@ async def _dispatch_backfill_individual(integration_id, job, individual_id):
 
 
 async def _finalize_backfill_individual(integration_id, job, ind, action_config, *, observations, state=None):
-    # Hand off the FULL cursor (timestamp + highest event id per sensor) to the
-    # steady-state pull, so the pull's event-id filter absorbs the accessory
-    # settling re-read at the boundary without re-emitting backfilled events.
+    # Merge the backfill watermark FORWARD into the steady-state pull cursor:
+    # per sensor, take max(existing, backfill) on both the timestamp and the
+    # highest event id. This carries backfill's event-ids forward (so the
+    # pull's accessory settling re-read dedups against them) without ever
+    # moving a running pull's cursor backward — action_backfill may already
+    # have claimed a forward cursor for this individual at job start (see
+    # _seed_pull_cursor_at_end), and a live pull may have advanced it further
+    # still while backfill was running.
     if state is not None:
-        existing = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
-        if not existing:
-            await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
-                                          json.loads(state.json()), source_id=ind.id)
+        existing_raw = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
+        existing_state = IndividualState.parse_obj(existing_raw) if existing_raw else IndividualState(
+            individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
+        )
+        for stid_str, backfill_ss in state.sensor_states.items():
+            stid = int(stid_str)
+            existing_ss = existing_state.get_sensor_state(stid)
+            candidate_stamps = [t for t in (existing_ss.latest_timestamp, backfill_ss.latest_timestamp) if t]
+            if candidate_stamps:
+                new_ts = max(candidate_stamps)
+                new_event_id = max(existing_ss.highest_event_id or 0, backfill_ss.highest_event_id or 0)
+                existing_state.update_sensor_state(stid, new_ts, new_event_id)
+        await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
+                                      json.loads(existing_state.json()), source_id=ind.id)
     await job.record_completion(observations)
     await job.decr_in_flight()
 
@@ -451,12 +504,7 @@ async def action_backfill_events_for_individual(integration, action_config: Back
     watermark_source = f"{action_config.job_id}.{ind.id}"
     log_reference = f"job:{action_config.job_id},individual:{ind.id}"
 
-    sensor_type_labels = [label.strip().lower() for label in ind.sensor_type_ids.split(",")]
-    sensor_type_ids = [
-        MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID[label]
-        for label in sensor_type_labels
-        if label in MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID
-    ]
+    sensor_type_ids = _supported_sensor_type_ids(ind)
     if not sensor_type_ids:
         return await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
 
@@ -470,11 +518,24 @@ async def action_backfill_events_for_individual(integration, action_config: Back
         sensor_type_timestamps[stid] = ss.latest_timestamp or action_config.start
         minimum_event_ids[stid] = (ss.highest_event_id or 0) + 1
 
+    # The scan position is a DURABLE floor, persisted every window regardless
+    # of whether events came back. Windows are anchored to it (below), not to
+    # the per-sensor event cursor above — otherwise a sensor that returns
+    # nothing for the whole range would never move its own cursor, and a
+    # re-trigger after a budget-exhausted step would recompute `current` from
+    # that unmoved cursor and rescan the same empty span forever (livelock).
+    persisted_scan_from = None
+    if saved and saved.get("scan_from"):
+        try:
+            persisted_scan_from = _ensure_utc(parse_date(saved["scan_from"]))
+        except Exception:
+            persisted_scan_from = None
+
     auth_config = client.get_auth_config(integration)
     deadline = time.monotonic() + 0.8 * settings.MAX_ACTION_EXECUTION_TIME
     window = DEFAULT_BATCH_WINDOW
     observations_sent = 0
-    current = min(sensor_type_timestamps.values())
+    current = persisted_scan_from if persisted_scan_from is not None else min(sensor_type_timestamps.values())
 
     mb_client = client.MovebankClient(
         base_url=integration.base_url, username=auth_config.username,
@@ -483,12 +544,11 @@ async def action_backfill_events_for_individual(integration, action_config: Back
     async with mb_client as mb:
         while current < action_config.end and time.monotonic() < deadline:
             end_at = min(action_config.end, current + window)
+            # All sensors sweep the same [current, end_at) window together —
+            # anchored to the scan floor, not each sensor's own cursor.
             events = []
             for stid in sensor_type_ids:
-                sensor_start = sensor_type_timestamps[stid]
-                if sensor_start > end_at:
-                    continue
-                query_start = _query_start_for_sensor(stid, sensor_start)
+                query_start = _query_start_for_sensor(stid, current)
                 async with movebank_slot(auth_config.username):
                     async for event in mb.get_individual_events_by_time(
                         study_id=action_config.study_id, individual_id=ind.id,
@@ -505,8 +565,13 @@ async def action_backfill_events_for_individual(integration, action_config: Back
             _advance_watermarks(state, events, sensor_type_ids, sensor_type_timestamps, minimum_event_ids)
             observations_sent += len(observations)
             current = current + window
+
+            # Persist the scan floor together with the sensor states in a
+            # single call, every window, regardless of whether events came back.
+            blob = json.loads(state.json())
+            blob["scan_from"] = current.isoformat()
             await state_manager.set_state(integration_id, BACKFILL_WATERMARK_ACTION_ID,
-                                          json.loads(state.json()), source_id=watermark_source)
+                                          blob, source_id=watermark_source)
 
     if current < action_config.end:
         # Budget exhausted mid-range: continue THIS individual on the next step.

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -342,7 +342,8 @@ async def action_backfill(integration, action_config: BackfillConfig):
         password=auth_config.password.get_secret_value(),
     )
     async with mb_client as mb:
-        rows = await mb.get_individuals_by_study(study_id=action_config.study_id)
+        async with movebank_slot(auth_config.username):
+            rows = await mb.get_individuals_by_study(study_id=action_config.study_id)
     individuals = list(generate_individuals(rows))
     if action_config.individual_ids:
         wanted = set(action_config.individual_ids)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -172,9 +172,19 @@ async def action_pull_observations(integration, action_config: PullObservationsC
         username=auth_config.username,
         password=auth_config.password.get_secret_value(),
     )
-    async with mb_client as mb:
-        async with movebank_slot(auth_config.username):
-            individual_rows = await mb.get_individuals_by_study(study_id=action_config.study_id)
+    try:
+        async with mb_client as mb:
+            async with movebank_slot(auth_config.username):
+                individual_rows = await mb.get_individuals_by_study(study_id=action_config.study_id)
+    except NoConnectionSlot:
+        # Movebank connection budget exhausted (e.g. a backfill is saturating it).
+        # This is a scheduled tick — skip cleanly and let the next one retry,
+        # rather than surfacing an action failure and triggering no sub-actions.
+        logger.info(
+            f"Skipping pull for study {action_config.study_id}: Movebank connection budget "
+            "exhausted; the next scheduled tick will retry."
+        )
+        return {"skipped": "no_connection_slot"}
 
     individuals = list(generate_individuals(individual_rows))
     logger.info(f"{len(individuals)} individuals found for study {action_config.study_id}")
@@ -289,17 +299,30 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
                     continue  # this sensor is already past the window
                 query_start = _query_start_for_sensor(sensor_type_id, sensor_start, minimum_event_ids[sensor_type_id])
                 count = 0
-                async with movebank_slot(auth_config.username):
-                    async for event in mb.get_individual_events_by_time(
-                        study_id=action_config.study_id,
-                        individual_id=ind.id,
-                        timestamp_start=query_start,
-                        timestamp_end=end_at,
-                        sensor_type_ids=[sensor_type_id],
-                        minimum_event_id=minimum_event_ids[sensor_type_id],
-                    ):
-                        events.append(event)  # single combined list; no per-sensor copy
-                        count += 1
+                try:
+                    async with movebank_slot(auth_config.username):
+                        async for event in mb.get_individual_events_by_time(
+                            study_id=action_config.study_id,
+                            individual_id=ind.id,
+                            timestamp_start=query_start,
+                            timestamp_end=end_at,
+                            sensor_type_ids=[sensor_type_id],
+                            minimum_event_id=minimum_event_ids[sensor_type_id],
+                        ):
+                            events.append(event)  # single combined list; no per-sensor copy
+                            count += 1
+                except NoConnectionSlot:
+                    # Budget exhausted (e.g. a backfill is saturating it). Prior
+                    # windows already persisted their cursors, so skip cleanly and
+                    # resume from the saved cursor on the next scheduled tick —
+                    # rather than raising a noisy action failure. This window's
+                    # partial fetch is discarded (not yet sent) and re-fetched next
+                    # tick; the event-id filter dedups.
+                    logger.info(
+                        f"Skipping {log_reference}: Movebank connection budget exhausted; "
+                        "resuming from the saved cursor on the next tick."
+                    )
+                    return {"skipped": "no_connection_slot", "observations_sent": total_observations_sent}
                 sensor_event_counts[sensor_type_id] = count
 
             if not sensor_event_counts:

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -389,25 +389,6 @@ def _resolve_start(start, ind) -> datetime:
     return datetime.now(tz=timezone.utc) - timedelta(days=3650)  # ~10y floor
 
 
-async def _resolve_end(integration_id: str, ind, now: datetime) -> tuple:
-    """Freeze the boundary where backfill meets the steady-state pull: the
-    individual's existing pull cursor if any, else now.
-
-    Returns (end, had_existing_cursor). When there was no existing cursor,
-    action_backfill claims it itself (seeds it to `now`, see
-    _seed_pull_cursor_at_end) so a concurrent steady-state pull run can't
-    compute its own lookback-based start and reach back into the range
-    backfill is about to cover.
-    """
-    saved = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
-    if saved:
-        state = IndividualState.parse_obj(saved)
-        stamps = [s.latest_timestamp for s in state.sensor_states.values() if s.latest_timestamp]
-        if stamps:
-            return min(stamps), True
-    return now, False
-
-
 async def _seed_pull_cursor_at_end(integration_id: str, study_id: str, ind, end: datetime) -> None:
     """Claim [end, +inf) for the steady-state pull cursor before backfill starts.
 
@@ -495,12 +476,11 @@ async def action_backfill(integration, action_config: BackfillConfig):
         )
     individuals = candidates
 
-    ranges = {}
-    had_cursor = {}
-    for i in individuals:
-        end_dt, cursor_existed = await _resolve_end(integration_id, i, now)
-        ranges[i.id] = (_resolve_start(action_config.start, i), end_dt)
-        had_cursor[i.id] = cursor_existed
+    # Every candidate reaching here has NO existing pull cursor (the filter
+    # above skipped those that did), so each individual's boundary is simply
+    # `now`: backfill covers [start, now) and the pull will cover [now, +inf)
+    # once its cursor is claimed below.
+    ranges = {i.id: (_resolve_start(action_config.start, i), now) for i in individuals}
 
     # Only individuals with a non-empty range are worth queuing.
     queued = [i for i in individuals if ranges[i.id][0] < ranges[i.id][1]]
@@ -517,8 +497,9 @@ async def action_backfill(integration, action_config: BackfillConfig):
     # backfill is about to cover (see _seed_pull_cursor_at_end).
     for i in queued:
         start_dt, end_dt = ranges[i.id]
-        if not had_cursor[i.id]:
-            await _seed_pull_cursor_at_end(integration_id, action_config.study_id, i, end_dt)
+        # No prior cursor (guaranteed by the skip filter) — claim the boundary
+        # so a concurrent */10 pull can't reach back into backfill's range.
+        await _seed_pull_cursor_at_end(integration_id, action_config.study_id, i, end_dt)
         await job.put_individual_config(
             i.id,
             BackfillEventsForIndividualConfig(

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -31,6 +31,7 @@ def mock_state_manager_redis(mocker):
     explicitly (e.g. the mock_state_store fixture below)."""
     mocker.patch("app.actions.handlers.state_manager.get_state", AsyncMock(return_value={}))
     mocker.patch("app.actions.handlers.state_manager.set_state", AsyncMock(return_value=None))
+    mocker.patch("app.actions.handlers.state_manager.delete_state", AsyncMock(return_value=None))
 
 
 @pytest.fixture

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -10,6 +11,17 @@ from app.actions.configurations import AuthenticateConfig
 def mock_activity_publish(mocker):
     """Keep @activity_logger from touching PubSub in tests."""
     mocker.patch("app.services.activity_logger.publish_event", AsyncMock(return_value=None))
+
+
+@pytest.fixture(autouse=True)
+def mock_connection_slot(mocker):
+    """Stub the Redis-backed connection semaphore so handler tests don't need a
+    live Redis. Tests that care about slot acquisition re-patch it explicitly."""
+    @asynccontextmanager
+    async def _noop_slot(username, *, ttl_seconds=600):
+        yield
+
+    return mocker.patch("app.actions.handlers.movebank_slot", side_effect=_noop_slot)
 
 
 @pytest.fixture

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -24,6 +24,15 @@ def mock_connection_slot(mocker):
     return mocker.patch("app.actions.handlers.movebank_slot", side_effect=_noop_slot)
 
 
+@pytest.fixture(autouse=True)
+def mock_state_manager_redis(mocker):
+    """Stub the state manager's Redis calls so handler tests don't need a live
+    Redis. Tests that care about specific saved state re-patch state_manager
+    explicitly (e.g. the mock_state_store fixture below)."""
+    mocker.patch("app.actions.handlers.state_manager.get_state", AsyncMock(return_value={}))
+    mocker.patch("app.actions.handlers.state_manager.set_state", AsyncMock(return_value=None))
+
+
 @pytest.fixture
 def integration():
     integration = MagicMock()

--- a/app/actions/tests/test_backfill_queue.py
+++ b/app/actions/tests/test_backfill_queue.py
@@ -29,6 +29,14 @@ def fake_redis():
     async def hget(key, field):
         return store["hashes"].get(key, {}).get(field)
 
+    async def hdel(key, *fields):
+        h = store["hashes"].get(key, {})
+        for f in fields:
+            h.pop(f, None)
+
+    async def exists(key):
+        return 1 if store["hashes"].get(key) else 0
+
     async def rpush(key, *vals):
         store["list"].extend(vals)
         return len(store["list"])
@@ -43,6 +51,8 @@ def fake_redis():
     client.hset = AsyncMock(side_effect=hset)
     client.hgetall = AsyncMock(side_effect=hgetall)
     client.hget = AsyncMock(side_effect=hget)
+    client.hdel = AsyncMock(side_effect=hdel)
+    client.exists = AsyncMock(side_effect=exists)
     client.rpush = AsyncMock(side_effect=rpush)
     client.lpop = AsyncMock(side_effect=lpop)
     client.llen = AsyncMock(side_effect=llen)
@@ -115,3 +125,27 @@ async def test_individual_configs_do_not_collide_with_meta_hash(job):
     snap = await job.snapshot()
     assert snap["total"] == 1
     assert await job.get_individual_config("total") == '{"total-config": true}'
+
+
+@pytest.mark.asyncio
+async def test_reset_attempts_clears_the_counter(job):
+    await job.seed(["a"], total=1, range_repr="r")
+    assert await job.incr_attempts("a") == 1
+    assert await job.incr_attempts("a") == 2
+    await job.reset_attempts("a")
+    # A fresh incr after reset starts back at 1, not 3.
+    assert await job.incr_attempts("a") == 1
+
+
+@pytest.mark.asyncio
+async def test_reset_attempts_is_a_noop_when_never_incremented(job):
+    await job.seed(["a"], total=1, range_repr="r")
+    await job.reset_attempts("a")  # must not raise
+    assert await job.incr_attempts("a") == 1
+
+
+@pytest.mark.asyncio
+async def test_exists_false_before_seed_true_after(job):
+    assert await job.exists() is False
+    await job.seed(["a"], total=1, range_repr="r")
+    assert await job.exists() is True

--- a/app/actions/tests/test_backfill_queue.py
+++ b/app/actions/tests/test_backfill_queue.py
@@ -75,3 +75,13 @@ async def test_attempts_counter(job):
     await job.seed(["a"], total=1, range_repr="r")
     assert await job.incr_attempts("a") == 1
     assert await job.incr_attempts("a") == 2
+
+
+@pytest.mark.asyncio
+async def test_pending_remaining_in_snapshot(job):
+    await job.seed(["a", "b", "c"], total=3, range_repr="r")
+    snap = await job.snapshot()
+    assert snap["pending_remaining"] == 3
+    await job.next_individual()
+    snap = await job.snapshot()
+    assert snap["pending_remaining"] == 2

--- a/app/actions/tests/test_backfill_queue.py
+++ b/app/actions/tests/test_backfill_queue.py
@@ -1,0 +1,77 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.actions.backfill_queue import BackfillJob
+
+
+@pytest.fixture
+def fake_redis():
+    # Minimal in-memory stand-in for the subset of redis.asyncio used here.
+    store = {"hash": {}, "list": []}
+
+    client = MagicMock()
+
+    async def hincrby(key, field, n):
+        store["hash"][field] = int(store["hash"].get(field, 0)) + n
+        return store["hash"][field]
+
+    async def hset(key, mapping=None, **kw):
+        store["hash"].update(mapping or kw)
+
+    async def hgetall(key):
+        return {k: str(v) for k, v in store["hash"].items()}
+
+    async def rpush(key, *vals):
+        store["list"].extend(vals)
+        return len(store["list"])
+
+    async def lpop(key):
+        return store["list"].pop(0) if store["list"] else None
+
+    async def llen(key):
+        return len(store["list"])
+
+    client.hincrby = AsyncMock(side_effect=hincrby)
+    client.hset = AsyncMock(side_effect=hset)
+    client.hgetall = AsyncMock(side_effect=hgetall)
+    client.rpush = AsyncMock(side_effect=rpush)
+    client.lpop = AsyncMock(side_effect=lpop)
+    client.llen = AsyncMock(side_effect=llen)
+    return client
+
+
+@pytest.fixture
+def job(mocker, fake_redis):
+    mocker.patch("app.actions.backfill_queue._client", return_value=fake_redis)
+    return BackfillJob("int-1", "job-1")
+
+
+@pytest.mark.asyncio
+async def test_seed_and_pop_order(job):
+    await job.seed(["a", "b", "c"], total=3, range_repr="[2024..2026)")
+    assert await job.next_individual() == "a"
+    assert await job.next_individual() == "b"
+    assert await job.next_individual() == "c"
+    assert await job.next_individual() is None
+
+
+@pytest.mark.asyncio
+async def test_in_flight_and_completion(job):
+    await job.seed(["a"], total=1, range_repr="r")
+    await job.incr_in_flight()
+    assert not await job.is_done()          # in_flight == 1
+    await job.next_individual()             # drain the queue
+    await job.record_completion(1500)
+    await job.decr_in_flight()
+    assert await job.is_done()              # pending empty AND in_flight == 0
+    snap = await job.snapshot()
+    assert snap["completed"] == 1
+    assert snap["observations_sent"] == 1500
+
+
+@pytest.mark.asyncio
+async def test_attempts_counter(job):
+    await job.seed(["a"], total=1, range_repr="r")
+    assert await job.incr_attempts("a") == 1
+    assert await job.incr_attempts("a") == 2

--- a/app/actions/tests/test_backfill_queue.py
+++ b/app/actions/tests/test_backfill_queue.py
@@ -8,19 +8,26 @@ from app.actions.backfill_queue import BackfillJob
 @pytest.fixture
 def fake_redis():
     # Minimal in-memory stand-in for the subset of redis.asyncio used here.
-    store = {"hash": {}, "list": []}
+    # Hashes are keyed by their Redis key so distinct hashes (meta vs. the
+    # per-individual configs hash) don't collide on field names.
+    store = {"hashes": {}, "list": []}
 
     client = MagicMock()
 
     async def hincrby(key, field, n):
-        store["hash"][field] = int(store["hash"].get(field, 0)) + n
-        return store["hash"][field]
+        h = store["hashes"].setdefault(key, {})
+        h[field] = int(h.get(field, 0)) + n
+        return h[field]
 
     async def hset(key, mapping=None, **kw):
-        store["hash"].update(mapping or kw)
+        h = store["hashes"].setdefault(key, {})
+        h.update(mapping or kw)
 
     async def hgetall(key):
-        return {k: str(v) for k, v in store["hash"].items()}
+        return {k: str(v) for k, v in store["hashes"].get(key, {}).items()}
+
+    async def hget(key, field):
+        return store["hashes"].get(key, {}).get(field)
 
     async def rpush(key, *vals):
         store["list"].extend(vals)
@@ -35,6 +42,7 @@ def fake_redis():
     client.hincrby = AsyncMock(side_effect=hincrby)
     client.hset = AsyncMock(side_effect=hset)
     client.hgetall = AsyncMock(side_effect=hgetall)
+    client.hget = AsyncMock(side_effect=hget)
     client.rpush = AsyncMock(side_effect=rpush)
     client.lpop = AsyncMock(side_effect=lpop)
     client.llen = AsyncMock(side_effect=llen)
@@ -85,3 +93,25 @@ async def test_pending_remaining_in_snapshot(job):
     await job.next_individual()
     snap = await job.snapshot()
     assert snap["pending_remaining"] == 2
+
+
+@pytest.mark.asyncio
+async def test_put_and_get_individual_config(job):
+    await job.put_individual_config("a", '{"foo": "bar"}')
+    assert await job.get_individual_config("a") == '{"foo": "bar"}'
+
+
+@pytest.mark.asyncio
+async def test_get_individual_config_missing_returns_none(job):
+    assert await job.get_individual_config("missing-id") is None
+
+
+@pytest.mark.asyncio
+async def test_individual_configs_do_not_collide_with_meta_hash(job):
+    # Meta hash and configs hash are distinct Redis keys, so an individual id
+    # that happens to match a meta field name must not leak/overwrite it.
+    await job.seed(["a"], total=1, range_repr="r")
+    await job.put_individual_config("total", '{"total-config": true}')
+    snap = await job.snapshot()
+    assert snap["total"] == 1
+    assert await job.get_individual_config("total") == '{"total-config": true}'

--- a/app/actions/tests/test_backfill_queue.py
+++ b/app/actions/tests/test_backfill_queue.py
@@ -149,3 +149,14 @@ async def test_exists_false_before_seed_true_after(job):
     assert await job.exists() is False
     await job.seed(["a"], total=1, range_repr="r")
     assert await job.exists() is True
+
+
+@pytest.mark.asyncio
+async def test_requeue_returns_individual_to_pending(job):
+    await job.seed(["a", "b"], total=2, range_repr="r")
+    assert await job.next_individual() == "a"      # pop a
+    await job.requeue("a")                          # put it back
+    # a is now at the tail: b comes first, then a.
+    assert await job.next_individual() == "b"
+    assert await job.next_individual() == "a"
+    assert await job.next_individual() is None

--- a/app/actions/tests/test_configurations.py
+++ b/app/actions/tests/test_configurations.py
@@ -48,3 +48,41 @@ def test_auth_config_unchanged():
     assert config.password.get_secret_value() == "p"
     from app.actions.core import ExecutableActionMixin
     assert issubclass(AuthenticateConfig, ExecutableActionMixin)
+
+
+def test_backfill_config_whole_study_all_data():
+    from app.actions.configurations import BackfillConfig
+    from app.actions.core import ExecutableActionMixin
+    config = BackfillConfig(study_id="12345", start="all")
+    assert config.individual_ids is None
+    assert config.start == "all"
+    assert issubclass(BackfillConfig, ExecutableActionMixin)
+
+
+def test_backfill_config_dated_and_filtered():
+    from datetime import datetime, timezone
+    from app.actions.configurations import BackfillConfig
+    config = BackfillConfig(
+        study_id="12345",
+        individual_ids=["111", "222"],
+        start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        backfill_max_concurrency=4,
+    )
+    assert config.individual_ids == ["111", "222"]
+    assert config.start.year == 2024
+    assert config.backfill_max_concurrency == 4
+
+
+def test_backfill_individual_config_is_internal_and_roundtrips():
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from app.actions.core import InternalActionConfiguration
+    from datetime import datetime, timezone
+    cfg = BackfillEventsForIndividualConfig(
+        study_id="12345", individual=INDIVIDUAL, job_id="job-1",
+        start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        end=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    assert isinstance(cfg, InternalActionConfiguration)
+    restored = BackfillEventsForIndividualConfig.parse_obj(cfg.dict())
+    assert restored.individual.id == "111"
+    assert restored.job_id == "job-1"

--- a/app/actions/tests/test_configurations.py
+++ b/app/actions/tests/test_configurations.py
@@ -60,16 +60,15 @@ def test_backfill_config_whole_study_all_data():
 
 
 def test_backfill_config_dated_and_filtered():
-    from datetime import datetime, timezone
     from app.actions.configurations import BackfillConfig
     config = BackfillConfig(
         study_id="12345",
         individual_ids=["111", "222"],
-        start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        start="2024-01-01",
         backfill_max_concurrency=4,
     )
     assert config.individual_ids == ["111", "222"]
-    assert config.start.year == 2024
+    assert config.start == "2024-01-01"
     assert config.backfill_max_concurrency == 4
 
 

--- a/app/actions/tests/test_configurations.py
+++ b/app/actions/tests/test_configurations.py
@@ -73,6 +73,20 @@ def test_backfill_config_dated_and_filtered():
     assert config.backfill_max_concurrency == 4
 
 
+def test_backfill_config_rejects_malformed_start_string():
+    from app.actions.configurations import BackfillConfig
+    # A garbage string must not silently fall through to full-history "all" —
+    # only a real datetime or the literal "all" is accepted.
+    with pytest.raises(ValidationError):
+        BackfillConfig(study_id="12345", start="not-a-real-date")
+
+
+def test_backfill_config_rejects_zero_concurrency():
+    from app.actions.configurations import BackfillConfig
+    with pytest.raises(ValidationError):
+        BackfillConfig(study_id="12345", start="all", backfill_max_concurrency=0)
+
+
 def test_backfill_individual_config_is_internal_and_roundtrips():
     from app.actions.configurations import BackfillEventsForIndividualConfig
     from app.actions.core import InternalActionConfiguration

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1027,6 +1027,10 @@ async def test_backfill_skips_reseed_when_job_already_active(
     from app.actions.configurations import BackfillConfig
     mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[INDIVIDUAL_ROW])
     mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=True))
+    # Genuinely active: work is in flight, so this must bail (not resume).
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 2, "completed": 0, "observations_sent": 0,
+                                          "in_flight": 2, "pending_remaining": 0, "range": "r"}))
     mock_seed = mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
     mock_put_config = mocker.patch("app.actions.backfill_queue.BackfillJob.put_individual_config", AsyncMock())
     mock_next = mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
@@ -1038,6 +1042,8 @@ async def test_backfill_skips_reseed_when_job_already_active(
     )
 
     assert result["already_active"] is True
+    assert not mock_seed.called
+    assert not mock_trigger.called
     assert "job_id" in result
     assert mock_seed.await_count == 0
     assert mock_put_config.await_count == 0
@@ -1100,3 +1106,64 @@ async def test_dispatch_backfill_individual_gives_up_after_exhausting_queue(mock
     assert mock_trigger.await_count == 0
     # Bounded: pending_remaining(2) + 1 for the passed-in id == 3 attempts max.
     assert job.get_individual_config.await_count <= 3
+
+
+@pytest.mark.asyncio
+async def test_backfill_resumes_stalled_job_when_nothing_in_flight(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    # A prior invocation seeded the job but crashed before dispatching: the job
+    # exists, has pending work, and nothing is in flight. A re-run must RESUME
+    # (dispatch from the queue), not bail out with already_active.
+    from app.actions.configurations import BackfillConfig
+    rows = [{**INDIVIDUAL_ROW, "id": str(i)} for i in range(3)]
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=rows)
+    pending = ["0", "1", "2"]
+
+    async def fake_next(self):
+        return pending.pop(0) if pending else None
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 3, "completed": 0, "observations_sent": 0,
+                                          "in_flight": 0, "pending_remaining": 3, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", fake_next)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.incr_in_flight", AsyncMock(return_value=1))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.get_individual_config",
+                 AsyncMock(return_value='{"study_id":"12345","individual":' +
+                           __import__("json").dumps(INDIVIDUAL_ROW) +
+                           ',"job_id":"job-x","start":"2024-01-01T00:00:00+00:00","end":"2024-02-01T00:00:00+00:00"}'))
+    mock_seed = mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+    mocker.patch("app.actions.handlers.settings.BACKFILL_MAX_CONCURRENCY", 2)
+
+    result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all"),
+    )
+
+    assert result.get("resumed") is True
+    assert result["dispatched"] == 2            # up to K, from the stalled queue
+    assert mock_trigger.await_count == 2
+    assert not mock_seed.called                 # did NOT re-seed
+
+
+@pytest.mark.asyncio
+async def test_backfill_bails_when_job_genuinely_active(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    # Job exists AND has work in flight: a re-run must NOT dispatch anything.
+    from app.actions.configurations import BackfillConfig
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[{**INDIVIDUAL_ROW, "id": "0"}])
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 3, "completed": 1, "observations_sent": 10,
+                                          "in_flight": 2, "pending_remaining": 1, "range": "r"}))
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all"),
+    )
+
+    assert result.get("already_active") is True
+    assert not mock_trigger.called

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -772,6 +772,10 @@ async def test_backfill_individual_finalize_error_is_not_misclassified_as_this_i
                  AsyncMock(return_value={"total": 2, "completed": 1, "observations_sent": 1, "in_flight": 1,
                                           "pending_remaining": 1, "range": "r"}))
     mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
+    # dispatch-next rolls back + requeues the next individual when trigger fails,
+    # then re-raises — mock both so the RuntimeError (not a Redis error) surfaces.
+    mocker.patch("app.actions.backfill_queue.BackfillJob.incr_in_flight", AsyncMock(return_value=2))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.requeue", AsyncMock())
     mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value="222"))
     # A real stored config for the NEXT individual, so dispatch-next actually
     # reaches trigger_action (rather than short-circuiting on a missing blob).
@@ -1206,3 +1210,40 @@ async def test_pull_events_skips_on_no_connection_slot(
     )
 
     assert result["skipped"] == "no_connection_slot"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rolls_back_and_requeues_on_trigger_failure(mocker):
+    # If trigger_action raises, in_flight must be rolled back and the individual
+    # re-queued (not lost) — otherwise in_flight stays inflated and the resume
+    # path can never fire.
+    from app.actions.backfill_queue import BackfillJob
+    from app.actions.handlers import _dispatch_backfill_individual
+    calls = {"incr": 0, "decr": 0, "requeued": []}
+
+    async def fake_snapshot(self):
+        return {"total": 1, "completed": 0, "observations_sent": 0, "in_flight": 0,
+                "pending_remaining": 0, "range": "r"}
+    async def fake_get_config(self, iid):
+        return ('{"study_id":"12345","individual":' + __import__("json").dumps(INDIVIDUAL_ROW) +
+                ',"job_id":"job-x","start":"2024-01-01T00:00:00+00:00","end":"2024-02-01T00:00:00+00:00"}')
+    async def fake_incr(self, n=1):
+        calls["incr"] += 1; return 1
+    async def fake_decr(self):
+        calls["decr"] += 1; return 0
+    async def fake_requeue(self, iid):
+        calls["requeued"].append(iid)
+    mocker.patch.object(BackfillJob, "snapshot", fake_snapshot)
+    mocker.patch.object(BackfillJob, "get_individual_config", fake_get_config)
+    mocker.patch.object(BackfillJob, "incr_in_flight", fake_incr)
+    mocker.patch.object(BackfillJob, "decr_in_flight", fake_decr)
+    mocker.patch.object(BackfillJob, "requeue", fake_requeue)
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock(side_effect=RuntimeError("pubsub down")))
+
+    job = BackfillJob("int-1", "job-x")
+    with pytest.raises(RuntimeError, match="pubsub down"):
+        await _dispatch_backfill_individual("int-1", job, "111")
+
+    assert calls["incr"] == 1
+    assert calls["decr"] == 1              # rolled back
+    assert calls["requeued"] == ["111"]    # not lost

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -707,8 +707,8 @@ async def test_backfill_individual_abandoned_after_max_attempts(
     from datetime import datetime, timezone
     mock_movebank_client.get_individual_events_by_time = mocker.MagicMock(side_effect=RuntimeError("mb down"))
     mocker.patch("app.actions.backfill_queue.BackfillJob.incr_attempts", AsyncMock(return_value=6))  # over the max
-    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
-    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mock_record_completion = mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mock_decr_in_flight = mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
     mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
     mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
                  AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0, "in_flight": 0, "range": "r"}))
@@ -723,3 +723,56 @@ async def test_backfill_individual_abandoned_after_max_attempts(
     )
     assert result["status"] == "abandoned"
     assert warn.called
+    # Finalize ran exactly once on the abandon path — no double-counting.
+    assert mock_record_completion.await_count == 1
+    assert mock_decr_in_flight.await_count == 1
+    # Abandoned with observations=0 and no state: no pull cursor handed off.
+    assert (str(integration.id), "pull_events_for_individual", "111") not in mock_state_store
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_finalize_error_is_not_misclassified_as_this_individuals_failure(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # A clean fetch/send loop reaches `end` and finalizes; if the dispatch-next
+    # trigger_action (part of finalize's post-processing) raises, that error must
+    # propagate rather than being caught by this individual's except-Exception —
+    # otherwise an already-completed individual would be retried/abandoned and
+    # _finalize_backfill_individual would run a second time (double
+    # record_completion / decr_in_flight).
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 3, tzinfo=timezone.utc)
+    events = [_gps_event(10, "2024-01-02 00:00:00.000")]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mock_record_completion = mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=False))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 2, "completed": 1, "observations_sent": 1, "in_flight": 1, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value="222"))
+    # A real stored config for the NEXT individual, so dispatch-next actually
+    # reaches trigger_action (rather than short-circuiting on a missing blob).
+    next_config = BackfillEventsForIndividualConfig(
+        study_id="12345", individual={**INDIVIDUAL_ROW, "id": "222"}, job_id="job-1", start=start, end=end,
+    )
+    mocker.patch("app.actions.backfill_queue.BackfillJob.get_individual_config",
+                 AsyncMock(return_value=next_config.json()))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.incr_in_flight", AsyncMock(return_value=2))
+    mocker.patch("app.actions.handlers.state_manager.set_if_absent", AsyncMock(return_value=True))
+    # The dispatch-next trigger_action (inside finalize, via _dispatch_backfill_individual)
+    # raises once the fetch loop has already completed successfully.
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock(side_effect=RuntimeError("pubsub down")))
+
+    with pytest.raises(RuntimeError, match="pubsub down"):
+        await action_backfill_events_for_individual(
+            integration=integration,
+            action_config=BackfillEventsForIndividualConfig(
+                study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+            ),
+        )
+
+    # This individual's own completion was recorded exactly once — the finalize
+    # error was NOT treated as this individual's failure (no retry/abandon).
+    assert mock_record_completion.await_count == 1

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -522,3 +522,153 @@ async def test_backfill_individual_retriggers_self_when_budget_exhausted(
     _, kwargs = mock_trigger.await_args_list[0]
     assert kwargs["action_id"] == "backfill_events_for_individual"
     assert kwargs["config"].individual.id == "111"
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_sparse_sensor_reaches_end_without_livelock(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # A sensor that returns NO events across a multi-window range must still
+    # make bounded progress: the scan floor (`scan_from`) advances every
+    # window regardless of whether events came back, so the step reaches
+    # `end` and finalizes instead of restarting at `start` forever.
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from datetime import datetime, timezone
+    from dateutil.parser import parse as parse_date
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 20, tzinfo=timezone.utc)  # 19 days -> multiple 5-day windows
+    mock_movebank_client.get_individual_events_by_time = make_events_generator([])
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0, "in_flight": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+    # Real-ish budget (not 0): plenty for a handful of mocked, near-instant windows.
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "completed"
+    assert not mock_trigger.called  # no self re-trigger: bounded, not livelocked
+    watermark = mock_state_store[(str(integration.id), "backfill_watermark", "job-1.111")]
+    assert parse_date(watermark["scan_from"]) >= end
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_resumes_scan_from_persisted_floor(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # Simulate a prior step that advanced the scan floor past `start` without
+    # ever getting an event for its sensor (so the per-sensor cursor is still
+    # unmoved, sitting at `start`). A fresh step must resume scanning from the
+    # persisted scan_from, not recompute `current` from the unmoved per-sensor
+    # cursor and rescan the already-covered span.
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from app.actions.client import IndividualState
+    from datetime import datetime, timezone
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 20, tzinfo=timezone.utc)
+    persisted_scan_from = datetime(2024, 1, 11, tzinfo=timezone.utc)  # past two 5-day windows
+    seeded_state = IndividualState(individual_id="111", study_id="12345")
+    blob = seeded_state.dict()
+    blob["scan_from"] = persisted_scan_from.isoformat()
+    mock_state_store[(str(integration.id), "backfill_watermark", "job-1.111")] = blob
+
+    captured_starts = []
+
+    async def _gen(**kwargs):
+        captured_starts.append(kwargs["timestamp_start"])
+        if False:
+            yield {}
+    mock_movebank_client.get_individual_events_by_time = _gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0, "in_flight": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "completed"
+    # First fetch must start from the persisted scan floor, not from `start`
+    # (which is where the never-advanced per-sensor cursor would place it).
+    assert captured_starts[0] == persisted_scan_from
+
+
+@pytest.mark.asyncio
+async def test_backfill_seeds_pull_cursor_at_end_and_finalize_merges_forward(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # End-to-end: an individual with no existing pull cursor gets one seeded
+    # to `now` (T0) when action_backfill starts, claiming [T0, +inf) so a
+    # concurrent steady-state pull can't reach back into backfill's range.
+    # After the sub-action finalizes, the pull cursor must carry backfill's
+    # highest event-id forward without moving its timestamp backward.
+    from app.actions.configurations import BackfillConfig, BackfillEventsForIndividualConfig
+    from app.actions.client import IndividualState
+    from datetime import datetime, timezone
+
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[INDIVIDUAL_ROW])
+    mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.put_individual_config", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    before = datetime.now(tz=timezone.utc)
+    backfill_result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all"),
+    )
+    after = datetime.now(tz=timezone.utc)
+    job_id = backfill_result["job_id"]
+
+    seeded = mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
+    seeded_state = IndividualState.parse_obj(seeded)
+    seeded_ss = seeded_state.get_sensor_state(653)
+    assert seeded_ss.highest_event_id == 0
+    assert before <= seeded_ss.latest_timestamp <= after
+
+    # Now run the sub-action to completion for a small range fully in the past.
+    events = [_gps_event(42, "2025-06-01 00:00:00.000")]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 1, "in_flight": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 3, tzinfo=timezone.utc)
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id=job_id, start=start, end=end,
+        ),
+    )
+    assert result["status"] == "completed"
+
+    merged = IndividualState.parse_obj(
+        mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
+    )
+    merged_ss = merged.get_sensor_state(653)
+    # Backfill's event-id carries forward...
+    assert merged_ss.highest_event_id == 42
+    # ...but the pull cursor's timestamp never moves backward past what it
+    # already claimed at seed time.
+    assert merged_ss.latest_timestamp == seeded_ss.latest_timestamp

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -5,7 +5,12 @@ import pytest
 
 from app.actions.client import IndividualState
 from app.actions.configurations import PullEventsForIndividualConfig, PullObservationsConfig
-from app.actions.handlers import action_backfill, action_pull_events_for_individual, action_pull_observations
+from app.actions.handlers import (
+    action_backfill,
+    action_backfill_events_for_individual,
+    action_pull_events_for_individual,
+    action_pull_observations,
+)
 from app.actions.tests.conftest import INDIVIDUAL_ROW, make_events_generator
 
 
@@ -382,6 +387,7 @@ async def test_backfill_seeds_queue_and_dispatches_up_to_k(
     rows = [{**INDIVIDUAL_ROW, "id": str(i)} for i in range(5)]
     mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=rows)
     seen = {}
+    configs = {}
 
     async def fake_seed(self, individual_ids, *, total, range_repr):
         seen["seeded"] = list(individual_ids); seen["total"] = total
@@ -389,9 +395,15 @@ async def test_backfill_seeds_queue_and_dispatches_up_to_k(
         return seen["seeded"].pop(0) if seen.get("seeded") else None
     async def fake_incr(self, n=1):
         return n
+    async def fake_put_config(self, individual_id, config_json):
+        configs[individual_id] = config_json
+    async def fake_get_config(self, individual_id):
+        return configs.get(individual_id)
     mocker.patch("app.actions.backfill_queue.BackfillJob.seed", fake_seed)
     mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", fake_next)
     mocker.patch("app.actions.backfill_queue.BackfillJob.incr_in_flight", fake_incr)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.put_individual_config", fake_put_config)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.get_individual_config", fake_get_config)
     mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
     mocker.patch("app.actions.handlers.settings.BACKFILL_MAX_CONCURRENCY", 3)
 
@@ -421,6 +433,7 @@ async def test_backfill_respects_individual_filter(
     mocker.patch("app.actions.backfill_queue.BackfillJob.seed", fake_seed)
     mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
     mocker.patch("app.actions.backfill_queue.BackfillJob.incr_in_flight", AsyncMock(return_value=1))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.put_individual_config", AsyncMock())
     mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
 
     await action_backfill(
@@ -441,3 +454,71 @@ async def test_backfill_acquires_connection_slot(
     slot = mocker.patch("app.actions.handlers.movebank_slot")
     await action_backfill(integration=integration, action_config=BackfillConfig(study_id="12345", start="all"))
     slot.assert_called_with("user")
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_finalizes_and_dispatches_next(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from app.actions.client import IndividualState
+    from datetime import datetime, timezone
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 3, tzinfo=timezone.utc)
+    # One small window of GPS events fully inside [start, end): the step reaches
+    # `end` in a single pass and finalizes.
+    events = [_gps_event(10, "2024-01-02 00:00:00.000")]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 1, "in_flight": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "completed"
+    # The steady-state pull cursor was written from the backfill watermark (ts + event id).
+    handed = mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
+    st = IndividualState.parse_obj(handed)
+    assert st.get_sensor_state(653).highest_event_id == 10
+    # Queue empty -> no next dispatch.
+    assert not mock_trigger.called
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_retriggers_self_when_budget_exhausted(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from datetime import datetime, timezone
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 1, 1, tzinfo=timezone.utc)   # huge range
+    events = [_gps_event(i, "2024-01-02 00:00:00.000") for i in range(3)]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    # Force the time budget to zero so the step stops after the first window.
+    mocker.patch("app.actions.handlers.settings.MAX_ACTION_EXECUTION_TIME", 0)
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "continued"
+    # It re-triggered ITSELF (same individual), not the next one.
+    assert mock_trigger.await_count == 1
+    _, kwargs = mock_trigger.await_args_list[0]
+    assert kwargs["action_id"] == "backfill_events_for_individual"
+    assert kwargs["config"].individual.id == "111"

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1167,3 +1167,42 @@ async def test_backfill_bails_when_job_genuinely_active(
 
     assert result.get("already_active") is True
     assert not mock_trigger.called
+
+
+@pytest.mark.asyncio
+async def test_pull_observations_skips_on_no_connection_slot(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    # A saturated Movebank connection budget must NOT fail the scheduled tick;
+    # it skips cleanly and no sub-actions are triggered (next tick retries).
+    from app.services.movebank_connections import NoConnectionSlot
+    def _raise(*a, **k):
+        raise NoConnectionSlot("full")
+    mocker.patch("app.actions.handlers.movebank_slot", _raise)
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_pull_observations(
+        integration=integration,
+        action_config=PullObservationsConfig(study_id="12345"),
+    )
+
+    assert result == {"skipped": "no_connection_slot"}
+    assert not mock_trigger.called
+
+
+@pytest.mark.asyncio
+async def test_pull_events_skips_on_no_connection_slot(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # NoConnectionSlot during the per-sensor fetch is a clean skip, not a failure.
+    from app.services.movebank_connections import NoConnectionSlot
+    def _raise(*a, **k):
+        raise NoConnectionSlot("full")
+    mocker.patch("app.actions.handlers.movebank_slot", _raise)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+
+    result = await action_pull_events_for_individual(
+        integration=integration, action_config=_sub_action_config()
+    )
+
+    assert result["skipped"] == "no_connection_slot"

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -5,7 +5,7 @@ import pytest
 
 from app.actions.client import IndividualState
 from app.actions.configurations import PullEventsForIndividualConfig, PullObservationsConfig
-from app.actions.handlers import action_pull_events_for_individual, action_pull_observations
+from app.actions.handlers import action_backfill, action_pull_events_for_individual, action_pull_observations
 from app.actions.tests.conftest import INDIVIDUAL_ROW, make_events_generator
 
 
@@ -372,3 +372,59 @@ async def test_pull_acquires_connection_slot(
     # keyed by the integration's Movebank username.
     assert slot.called
     slot.assert_called_with("user")
+
+
+@pytest.mark.asyncio
+async def test_backfill_seeds_queue_and_dispatches_up_to_k(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    from app.actions.configurations import BackfillConfig
+    rows = [{**INDIVIDUAL_ROW, "id": str(i)} for i in range(5)]
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=rows)
+    seen = {}
+
+    async def fake_seed(self, individual_ids, *, total, range_repr):
+        seen["seeded"] = list(individual_ids); seen["total"] = total
+    async def fake_next(self):
+        return seen["seeded"].pop(0) if seen.get("seeded") else None
+    async def fake_incr(self, n=1):
+        return n
+    mocker.patch("app.actions.backfill_queue.BackfillJob.seed", fake_seed)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", fake_next)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.incr_in_flight", fake_incr)
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+    mocker.patch("app.actions.handlers.settings.BACKFILL_MAX_CONCURRENCY", 3)
+
+    result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all"),
+    )
+
+    assert result["individuals"] == 5
+    assert result["dispatched"] == 3            # K, not all 5
+    assert mock_trigger.await_count == 3
+    _, kwargs = mock_trigger.await_args_list[0]
+    assert kwargs["action_id"] == "backfill_events_for_individual"
+    assert kwargs["config"].job_id == result["job_id"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_respects_individual_filter(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    from app.actions.configurations import BackfillConfig
+    rows = [{**INDIVIDUAL_ROW, "id": str(i)} for i in range(5)]
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=rows)
+    captured = {}
+    async def fake_seed(self, individual_ids, *, total, range_repr):
+        captured["ids"] = list(individual_ids)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.seed", fake_seed)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.incr_in_flight", AsyncMock(return_value=1))
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all", individual_ids=["2", "4"]),
+    )
+    assert set(captured["ids"]) == {"2", "4"}

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -81,9 +81,13 @@ def mock_state_store(mocker):
     async def set_state(integration_id, action_id, state, source_id="no-source", expire=None):
         store[(str(integration_id), action_id, source_id)] = state
 
+    async def delete_state(integration_id, action_id, source_id="no-source"):
+        store.pop((str(integration_id), action_id, source_id), None)
+
     manager = mocker.patch("app.actions.handlers.state_manager")
     manager.get_state = AsyncMock(side_effect=get_state)
     manager.set_state = AsyncMock(side_effect=set_state)
+    manager.delete_state = AsyncMock(side_effect=delete_state)
     return store
 
 
@@ -404,6 +408,10 @@ async def test_backfill_seeds_queue_and_dispatches_up_to_k(
     mocker.patch("app.actions.backfill_queue.BackfillJob.incr_in_flight", fake_incr)
     mocker.patch("app.actions.backfill_queue.BackfillJob.put_individual_config", fake_put_config)
     mocker.patch("app.actions.backfill_queue.BackfillJob.get_individual_config", fake_get_config)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=False))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 5, "completed": 0, "observations_sent": 0, "in_flight": 0,
+                                          "pending_remaining": 0, "range": "r"}))
     mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
     mocker.patch("app.actions.handlers.settings.BACKFILL_MAX_CONCURRENCY", 3)
 
@@ -434,6 +442,7 @@ async def test_backfill_respects_individual_filter(
     mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
     mocker.patch("app.actions.backfill_queue.BackfillJob.incr_in_flight", AsyncMock(return_value=1))
     mocker.patch("app.actions.backfill_queue.BackfillJob.put_individual_config", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=False))
     mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
 
     await action_backfill(
@@ -451,6 +460,7 @@ async def test_backfill_acquires_connection_slot(
     mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[])
     mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
     mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=False))
     slot = mocker.patch("app.actions.handlers.movebank_slot")
     await action_backfill(integration=integration, action_config=BackfillConfig(study_id="12345", start="all"))
     slot.assert_called_with("user")
@@ -476,6 +486,7 @@ async def test_backfill_individual_finalizes_and_dispatches_next(
                  AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 1, "in_flight": 0, "range": "r"}))
     mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
     mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
     mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
 
     result = await action_backfill_events_for_individual(
@@ -492,6 +503,8 @@ async def test_backfill_individual_finalizes_and_dispatches_next(
     assert st.get_sensor_state(653).highest_event_id == 10
     # Queue empty -> no next dispatch.
     assert not mock_trigger.called
+    # The backfill watermark is cleaned up after a successful finalize.
+    assert (str(integration.id), "backfill_watermark", "job-1.111") not in mock_state_store
 
 
 @pytest.mark.asyncio
@@ -507,6 +520,7 @@ async def test_backfill_individual_retriggers_self_when_budget_exhausted(
     mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
     # Force the time budget to zero so the step stops after the first window.
     mocker.patch("app.actions.handlers.settings.MAX_ACTION_EXECUTION_TIME", 0)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
     mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
 
     result = await action_backfill_events_for_individual(
@@ -534,7 +548,6 @@ async def test_backfill_individual_sparse_sensor_reaches_end_without_livelock(
     # `end` and finalizes instead of restarting at `start` forever.
     from app.actions.configurations import BackfillEventsForIndividualConfig
     from datetime import datetime, timezone
-    from dateutil.parser import parse as parse_date
     start = datetime(2024, 1, 1, tzinfo=timezone.utc)
     end = datetime(2024, 1, 20, tzinfo=timezone.utc)  # 19 days -> multiple 5-day windows
     mock_movebank_client.get_individual_events_by_time = make_events_generator([])
@@ -545,6 +558,7 @@ async def test_backfill_individual_sparse_sensor_reaches_end_without_livelock(
                  AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0, "in_flight": 0, "range": "r"}))
     mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
     mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
     mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
     # Real-ish budget (not 0): plenty for a handful of mocked, near-instant windows.
 
@@ -557,8 +571,10 @@ async def test_backfill_individual_sparse_sensor_reaches_end_without_livelock(
 
     assert result["status"] == "completed"
     assert not mock_trigger.called  # no self re-trigger: bounded, not livelocked
-    watermark = mock_state_store[(str(integration.id), "backfill_watermark", "job-1.111")]
-    assert parse_date(watermark["scan_from"]) >= end
+    # The watermark is deleted on a successful finalize (see MINOR-4 fix) — its
+    # absence here is proof the scan floor actually reached `end` in-bounds
+    # rather than getting stuck mid-range.
+    assert (str(integration.id), "backfill_watermark", "job-1.111") not in mock_state_store
 
 
 @pytest.mark.asyncio
@@ -595,6 +611,7 @@ async def test_backfill_individual_resumes_scan_from_persisted_floor(
                  AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0, "in_flight": 0, "range": "r"}))
     mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
     mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
     mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
 
     result = await action_backfill_events_for_individual(
@@ -627,6 +644,7 @@ async def test_backfill_seeds_pull_cursor_at_end_and_finalize_merges_forward(
     mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
     mocker.patch("app.actions.backfill_queue.BackfillJob.put_individual_config", AsyncMock())
     mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=False))
     mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
 
     before = datetime.now(tz=timezone.utc)
@@ -652,6 +670,7 @@ async def test_backfill_seeds_pull_cursor_at_end_and_finalize_merges_forward(
     mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
                  AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 1, "in_flight": 0, "range": "r"}))
     mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
 
     start = datetime(2025, 1, 1, tzinfo=timezone.utc)
     end = datetime(2025, 1, 3, tzinfo=timezone.utc)
@@ -750,7 +769,9 @@ async def test_backfill_individual_finalize_error_is_not_misclassified_as_this_i
     mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
     mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=False))
     mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
-                 AsyncMock(return_value={"total": 2, "completed": 1, "observations_sent": 1, "in_flight": 1, "range": "r"}))
+                 AsyncMock(return_value={"total": 2, "completed": 1, "observations_sent": 1, "in_flight": 1,
+                                          "pending_remaining": 1, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
     mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value="222"))
     # A real stored config for the NEXT individual, so dispatch-next actually
     # reaches trigger_action (rather than short-circuiting on a missing blob).
@@ -776,3 +797,306 @@ async def test_backfill_individual_finalize_error_is_not_misclassified_as_this_i
     # This individual's own completion was recorded exactly once — the finalize
     # error was NOT treated as this individual's failure (no retry/abandon).
     assert mock_record_completion.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_pull_accessory_query_not_widened_without_prior_events(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # A freshly-seeded accessory cursor (highest_event_id == 0 — e.g. right
+    # after _seed_pull_cursor_at_end at backfill start) must NOT be widened:
+    # doing so would re-read [T-settling, T) with minimum_event_id=1 and
+    # re-emit duplicates of everything already sent in that span.
+    from app.actions.client import IndividualState
+    from datetime import datetime, timezone
+    cursor_ts = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    state = IndividualState(individual_id="111", study_id="12345")
+    state.update_sensor_state(7842954, cursor_ts, 0)
+    mock_state_store[(str(integration.id), "pull_events_for_individual", "111")] = state.dict()
+
+    captured = {}
+
+    async def _gen(**kwargs):
+        captured.update(kwargs)
+        if False:
+            yield {}
+    mock_movebank_client.get_individual_events_by_time = _gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+
+    await action_pull_events_for_individual(
+        integration=integration,
+        action_config=_sub_action_config(individual_overrides={"sensor_type_ids": "accessory-measurements"}),
+    )
+
+    assert captured["sensor_type_ids"] == [7842954]
+    # No widening: query starts exactly at the cursor, not settling hours before it.
+    assert captured["timestamp_start"] == cursor_ts
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_density_window_applies(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # A high-frequency individual must get a narrower, density-sized window in
+    # backfill too (mirroring the pull's _compute_batch_window), not always
+    # the 5-day default.
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from datetime import datetime, timezone
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 31, tzinfo=timezone.utc)  # 30-day range
+    gen, calls = make_counting_events_generator(0)
+    mock_movebank_client.get_individual_events_by_time = gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0, "in_flight": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345",
+            individual={**INDIVIDUAL_ROW, "number_of_events": "60000"},
+            job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "completed"
+    # 30-day range at a ~2.5-day density window => 12 windows, not the 6 the
+    # 5-day default would take.
+    assert calls["count"] == 12
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_stops_at_per_step_record_backstop(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # A dense window can return far more than density sizing expects. The
+    # per-step backstop must stop taking more windows once this step's total
+    # crosses it, persisting progress and re-triggering rather than risking
+    # the invocation running past its execution budget.
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from datetime import datetime, timezone
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 1, tzinfo=timezone.utc)  # huge range, many windows available
+    gen, calls = make_counting_events_generator(3000)  # 3000 events/window, GPS-only
+    mock_movebank_client.get_individual_events_by_time = gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "continued"
+    # 4 windows * 3000 = 12000 >= the 10000 backstop: stopped rather than
+    # continuing to sweep the (still huge) remaining range in one invocation.
+    assert calls["count"] == 4
+    assert result["observations_sent"] == 12000
+    assert mock_trigger.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_checks_deadline_between_sensor_fetches(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # The deadline must be checked BETWEEN per-sensor fetches within a window,
+    # not only between windows: a dense window's own fetches can exceed the
+    # budget, and there is no PubSub redelivery to recover a killed step.
+    # Uses a real (tiny) deadline and a real sleep on the first sensor's fetch
+    # rather than mocking time.monotonic, which asyncio's own loop internals
+    # also call (mocking it globally breaks the event loop itself).
+    import asyncio
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from datetime import datetime, timezone
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 3, tzinfo=timezone.utc)
+    calls = {"gps": 0, "accessory": 0}
+
+    async def _gen(**kwargs):
+        if kwargs["sensor_type_ids"] == [653]:
+            calls["gps"] += 1
+            await asyncio.sleep(0.1)  # simulate a slow first-sensor request
+        else:
+            calls["accessory"] += 1
+        if False:
+            yield {}
+    mock_movebank_client.get_individual_events_by_time = _gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
+    # A tiny real budget: comfortably survives until after the GPS fetch is
+    # requested, but is exhausted by the time the 0.1s sleep completes.
+    mocker.patch("app.actions.handlers.settings.MAX_ACTION_EXECUTION_TIME", 0.01)
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345",
+            individual={**INDIVIDUAL_ROW, "sensor_type_ids": "gps, accessory-measurements"},
+            job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "continued"
+    assert calls["gps"] == 1
+    assert calls["accessory"] == 0  # deadline hit before this sensor's fetch
+    assert mock_trigger.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_resets_attempts_after_successful_step(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from datetime import datetime, timezone
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 3, tzinfo=timezone.utc)
+    events = [_gps_event(10, "2024-01-02 00:00:00.000")]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 1, "in_flight": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+    mock_reset = mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "completed"
+    mock_reset.assert_awaited_once_with("111")
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_individuals_with_existing_cursor(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    from app.actions.configurations import BackfillConfig
+    from app.actions.client import IndividualState
+    from datetime import datetime, timezone
+    rows = [{**INDIVIDUAL_ROW, "id": str(i)} for i in range(3)]
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=rows)
+    # Individual "1" already has a steady-state pull cursor: backfill is for
+    # initial load only, so it must be skipped, not queued.
+    existing_state = IndividualState(individual_id="1", study_id="12345")
+    existing_state.update_sensor_state(653, datetime(2026, 1, 1, tzinfo=timezone.utc), 5)
+    mock_state_store[(str(integration.id), "pull_events_for_individual", "1")] = existing_state.dict()
+
+    mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.put_individual_config", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=False))
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+    warn = mocker.patch("app.actions.handlers.logger.warning")
+
+    result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all"),
+    )
+
+    assert result["individuals"] == 2       # "1" excluded
+    assert result["skipped_existing"] == 1
+    assert warn.call_count == 1             # exactly one summary warning
+    assert "skipped 1 individuals" in warn.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_reseed_when_job_already_active(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    # A redelivered/double-clicked backfill command hashes to the SAME job_id.
+    # If that job is already active, action_backfill must not re-seed (which
+    # would re-zero counters and re-RPUSH/double-dispatch individuals already
+    # in flight).
+    from app.actions.configurations import BackfillConfig
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[INDIVIDUAL_ROW])
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=True))
+    mock_seed = mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
+    mock_put_config = mocker.patch("app.actions.backfill_queue.BackfillJob.put_individual_config", AsyncMock())
+    mock_next = mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all"),
+    )
+
+    assert result["already_active"] is True
+    assert "job_id" in result
+    assert mock_seed.await_count == 0
+    assert mock_put_config.await_count == 0
+    assert mock_next.await_count == 0
+    assert mock_trigger.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_backfill_individual_skips_missing_config_to_next_pending(mocker):
+    # If the first individual's stored config is missing (e.g. a lost/evicted
+    # Redis entry), the dispatch driver must advance to the next pending
+    # individual instead of silently stalling the cascade.
+    from app.actions.handlers import _dispatch_backfill_individual
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from datetime import datetime, timezone
+
+    job = mocker.MagicMock()
+    job.job_id = "job-1"
+    job.snapshot = AsyncMock(return_value={
+        "pending_remaining": 1, "total": 2, "completed": 0,
+        "observations_sent": 0, "in_flight": 0, "range": "r",
+    })
+    good_config = BackfillEventsForIndividualConfig(
+        study_id="12345", individual={**INDIVIDUAL_ROW, "id": "222"}, job_id="job-1",
+        start=datetime(2024, 1, 1, tzinfo=timezone.utc), end=datetime(2024, 1, 3, tzinfo=timezone.utc),
+    )
+    # "111"'s config is missing; "222" (next in the pending queue) has one.
+    job.get_individual_config = AsyncMock(side_effect=[None, good_config.json()])
+    job.next_individual = AsyncMock(return_value="222")
+    job.incr_in_flight = AsyncMock(return_value=1)
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    await _dispatch_backfill_individual("int-1", job, "111")
+
+    job.get_individual_config.assert_any_call("111")
+    job.get_individual_config.assert_any_call("222")
+    assert mock_trigger.await_count == 1
+    _, kwargs = mock_trigger.await_args_list[0]
+    assert kwargs["config"].individual.id == "222"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_backfill_individual_gives_up_after_exhausting_queue(mocker):
+    # Every stored config is missing (e.g. the whole configs hash was lost):
+    # the fallback loop must be bounded by the queue's length, not spin forever.
+    from app.actions.handlers import _dispatch_backfill_individual
+
+    job = mocker.MagicMock()
+    job.job_id = "job-1"
+    job.snapshot = AsyncMock(return_value={
+        "pending_remaining": 2, "total": 3, "completed": 0,
+        "observations_sent": 0, "in_flight": 0, "range": "r",
+    })
+    job.get_individual_config = AsyncMock(return_value=None)
+    job.next_individual = AsyncMock(side_effect=["222", "333", None])
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    await _dispatch_backfill_individual("int-1", job, "111")
+
+    assert mock_trigger.await_count == 0
+    # Bounded: pending_remaining(2) + 1 for the passed-in id == 3 attempts max.
+    assert job.get_individual_config.await_count <= 3

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -368,5 +368,7 @@ async def test_pull_acquires_connection_slot(
         integration=integration, action_config=_sub_action_config()
     )
 
-    # The pull opened at least one connection under the shared semaphore.
+    # The pull opened at least one connection under the shared semaphore,
+    # keyed by the integration's Movebank username.
     assert slot.called
+    slot.assert_called_with("user")

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -428,3 +428,16 @@ async def test_backfill_respects_individual_filter(
         action_config=BackfillConfig(study_id="12345", start="all", individual_ids=["2", "4"]),
     )
     assert set(captured["ids"]) == {"2", "4"}
+
+
+@pytest.mark.asyncio
+async def test_backfill_acquires_connection_slot(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    from app.actions.configurations import BackfillConfig
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[])
+    mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    slot = mocker.patch("app.actions.handlers.movebank_slot")
+    await action_backfill(integration=integration, action_config=BackfillConfig(study_id="12345", start="all"))
+    slot.assert_called_with("user")

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -672,3 +672,54 @@ async def test_backfill_seeds_pull_cursor_at_end_and_finalize_merges_forward(
     # ...but the pull cursor's timestamp never moves backward past what it
     # already claimed at seed time.
     assert merged_ss.latest_timestamp == seeded_ss.latest_timestamp
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_backs_off_when_no_slot(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from app.services.movebank_connections import NoConnectionSlot
+    from datetime import datetime, timezone
+    def _raise(*a, **k):
+        raise NoConnectionSlot("full")
+    mocker.patch("app.actions.handlers.movebank_slot", _raise)
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1",
+            start=datetime(2024, 1, 1, tzinfo=timezone.utc), end=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ),
+    )
+    assert result["status"] == "backoff"
+    # Re-triggered self to retry later; did not finalize.
+    assert mock_trigger.await_count == 1
+    assert mock_trigger.await_args_list[0].kwargs["config"].individual.id == "111"
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_abandoned_after_max_attempts(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from datetime import datetime, timezone
+    mock_movebank_client.get_individual_events_by_time = mocker.MagicMock(side_effect=RuntimeError("mb down"))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.incr_attempts", AsyncMock(return_value=6))  # over the max
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0, "in_flight": 0, "range": "r"}))
+    warn = mocker.patch("app.actions.handlers.logger.warning")
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1",
+            start=datetime(2024, 1, 1, tzinfo=timezone.utc), end=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ),
+    )
+    assert result["status"] == "abandoned"
+    assert warn.called

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -321,3 +321,52 @@ async def test_pull_events_advances_event_id_cursor_when_timestamps_unparseable(
     saved = mock_state_store.get((str(integration.id), "pull_events_for_individual", "111"))
     assert saved is not None
     assert IndividualState.parse_obj(saved).get_sensor_state(653).highest_event_id == 100
+
+
+@pytest.mark.asyncio
+async def test_pull_accessory_query_applies_settling_margin(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # An accessory-only individual with a saved cursor: the query start must be
+    # pushed back by ACCESSORY_SETTLING_HOURS so multi-hour-late records are caught.
+    from app.actions.client import IndividualState
+    from datetime import datetime, timezone
+    cursor_ts = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    state = IndividualState(individual_id="111", study_id="12345")
+    state.update_sensor_state(7842954, cursor_ts, 500)
+    mock_state_store[(str(integration.id), "pull_events_for_individual", "111")] = state.dict()
+
+    captured = {}
+
+    async def _gen(**kwargs):
+        captured.update(kwargs)
+        if False:
+            yield {}
+    mock_movebank_client.get_individual_events_by_time = _gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+
+    await action_pull_events_for_individual(
+        integration=integration,
+        action_config=_sub_action_config(individual_overrides={"sensor_type_ids": "accessory-measurements"}),
+    )
+
+    # First fetch for the accessory sensor starts >= 12h before the cursor.
+    assert captured["sensor_type_ids"] == [7842954]
+    assert captured["timestamp_start"] <= cursor_ts - timedelta(hours=12)
+
+
+@pytest.mark.asyncio
+async def test_pull_acquires_connection_slot(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    events = [_gps_event(100, "2026-01-01 10:00:00.000")]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    slot = mocker.patch("app.actions.handlers.movebank_slot")
+
+    await action_pull_events_for_individual(
+        integration=integration, action_config=_sub_action_config()
+    )
+
+    # The pull opened at least one connection under the shared semaphore.
+    assert slot.called

--- a/app/services/movebank_connections.py
+++ b/app/services/movebank_connections.py
@@ -1,4 +1,5 @@
 import hashlib
+import logging
 import time
 import uuid
 from contextlib import asynccontextmanager
@@ -6,6 +7,8 @@ from contextlib import asynccontextmanager
 import redis.asyncio as redis
 
 from app import settings
+
+logger = logging.getLogger(__name__)
 
 
 class NoConnectionSlot(Exception):
@@ -63,4 +66,11 @@ async def movebank_slot(username: str, *, ttl_seconds: int = 600):
     try:
         yield
     finally:
-        await client.zrem(key, token)
+        # Best-effort release: a failed zrem must not turn an otherwise-successful
+        # Movebank call into an action failure (spurious retry). The slot is
+        # time-bounded and purged on the next acquire, so a missed release
+        # self-heals via TTL.
+        try:
+            await client.zrem(key, token)
+        except Exception as exc:
+            logger.warning(f"Failed to release Movebank connection slot (will expire via TTL): {exc}")

--- a/app/services/movebank_connections.py
+++ b/app/services/movebank_connections.py
@@ -30,10 +30,16 @@ def connection_key(username: str) -> str:
     return f"movebank:connections:{digest}"
 
 
+_shared_client = None
+
+
 def _client() -> redis.Redis:
-    return redis.Redis(
-        host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=settings.REDIS_STATE_DB
-    )
+    global _shared_client
+    if _shared_client is None:
+        _shared_client = redis.Redis(
+            host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=settings.REDIS_STATE_DB
+        )
+    return _shared_client
 
 
 @asynccontextmanager

--- a/app/services/movebank_connections.py
+++ b/app/services/movebank_connections.py
@@ -1,0 +1,60 @@
+import hashlib
+import time
+import uuid
+from contextlib import asynccontextmanager
+
+import redis.asyncio as redis
+
+from app import settings
+
+
+class NoConnectionSlot(Exception):
+    """Raised when the Movebank connection budget for a username is exhausted."""
+
+
+# Atomic acquire: purge expired slots, then add a new slot only if under the
+# ceiling. KEYS[1]=zset key. ARGV: now, expiry, ceiling, token.
+# Returns 1 if acquired, 0 if at capacity.
+_ACQUIRE_LUA = """
+redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[1])
+if redis.call('ZCARD', KEYS[1]) < tonumber(ARGV[3]) then
+    redis.call('ZADD', KEYS[1], ARGV[2], ARGV[4])
+    return 1
+end
+return 0
+"""
+
+
+def connection_key(username: str) -> str:
+    digest = hashlib.sha256(username.encode("utf-8")).hexdigest()[:16]
+    return f"movebank:connections:{digest}"
+
+
+def _client() -> redis.Redis:
+    return redis.Redis(
+        host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=settings.REDIS_STATE_DB
+    )
+
+
+@asynccontextmanager
+async def movebank_slot(username: str, *, ttl_seconds: int = 600):
+    """Acquire one Movebank connection slot for `username`, shared across every
+    integration on the same Redis. Raises NoConnectionSlot if at capacity.
+
+    Slots are members of a per-username sorted set scored by expiry time, so a
+    crashed holder's slot self-expires (purged on the next acquire) rather than
+    leaking the budget permanently.
+    """
+    client = _client()
+    key = connection_key(username)
+    token = str(uuid.uuid4())
+    now = time.time()
+    acquired = await client.eval(
+        _ACQUIRE_LUA, 1, key, now, now + ttl_seconds, settings.MOVEBANK_MAX_CONNECTIONS, token
+    )
+    if not acquired:
+        raise NoConnectionSlot(f"No Movebank connection slot available (limit {settings.MOVEBANK_MAX_CONNECTIONS}).")
+    try:
+        yield
+    finally:
+        await client.zrem(key, token)

--- a/app/services/tests/test_movebank_connections.py
+++ b/app/services/tests/test_movebank_connections.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from app.services import movebank_connections
 from app.services.movebank_connections import (
     NoConnectionSlot,
     connection_key,
@@ -21,13 +22,19 @@ def test_connection_key_hashes_username():
 
 @pytest.fixture
 def mock_redis(mocker):
+    # Reset singleton before each test so the mock can intercept client creation
+    movebank_connections._shared_client = None
+
     client = MagicMock()
     client.eval = AsyncMock(return_value=1)      # acquired by default
     client.zrem = AsyncMock(return_value=1)
     redis_module = MagicMock()
     redis_module.Redis.return_value = client
     mocker.patch("app.services.movebank_connections.redis", redis_module)
-    return client
+
+    # Clean up after test
+    yield client
+    movebank_connections._shared_client = None
 
 
 @pytest.mark.asyncio

--- a/app/services/tests/test_movebank_connections.py
+++ b/app/services/tests/test_movebank_connections.py
@@ -1,0 +1,56 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.movebank_connections import (
+    NoConnectionSlot,
+    connection_key,
+    movebank_slot,
+)
+
+
+def test_connection_key_hashes_username():
+    key = connection_key("gundi_user")
+    assert key.startswith("movebank:connections:")
+    # Plaintext username must not appear in the key.
+    assert "gundi_user" not in key
+    # Stable and same-length for any username.
+    assert key == connection_key("gundi_user")
+    assert len(connection_key("a")) == len(connection_key("a-much-longer-name"))
+
+
+@pytest.fixture
+def mock_redis(mocker):
+    client = MagicMock()
+    client.eval = AsyncMock(return_value=1)      # acquired by default
+    client.zrem = AsyncMock(return_value=1)
+    redis_module = MagicMock()
+    redis_module.Redis.return_value = client
+    mocker.patch("app.services.movebank_connections.redis", redis_module)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_movebank_slot_acquires_and_releases(mock_redis):
+    async with movebank_slot("gundi_user"):
+        pass
+    assert mock_redis.eval.await_count == 1      # acquire
+    assert mock_redis.zrem.await_count == 1      # release
+
+
+@pytest.mark.asyncio
+async def test_movebank_slot_raises_when_full(mock_redis):
+    mock_redis.eval = AsyncMock(return_value=0)  # at capacity
+    with pytest.raises(NoConnectionSlot):
+        async with movebank_slot("gundi_user"):
+            pass
+    # Nothing acquired, so nothing released.
+    assert mock_redis.zrem.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_movebank_slot_releases_on_exception(mock_redis):
+    with pytest.raises(ValueError):
+        async with movebank_slot("gundi_user"):
+            raise ValueError("boom")
+    assert mock_redis.zrem.await_count == 1      # released despite the error

--- a/app/settings/integration.py
+++ b/app/settings/integration.py
@@ -1,1 +1,14 @@
 # Add your integration-specific settings here
+from app.settings.base import env
+
+# Movebank connection budget, shared across all integrations using the same
+# Movebank username (Movebank documents ~31 simultaneous connections per user).
+MOVEBANK_MAX_CONNECTIONS = env.int("MOVEBANK_MAX_CONNECTIONS", 25)
+# Accessory-measurements records can arrive at Movebank hours after their
+# timestamp; the accessory query re-reads this many hours so late arrivals are
+# caught (the event-id filter drops already-sent events, so no duplicates).
+ACCESSORY_SETTLING_HOURS = env.int("ACCESSORY_SETTLING_HOURS", 12)
+# Rolling-queue width for a backfill job: how many individuals are in flight at
+# once. Deliberately below MOVEBANK_MAX_CONNECTIONS so backfill never starves
+# the steady-state pull or other integrations on the same username.
+BACKFILL_MAX_CONCURRENCY = env.int("BACKFILL_MAX_CONCURRENCY", 8)

--- a/docs/superpowers/plans/2026-07-21-movebank-backfill.md
+++ b/docs/superpowers/plans/2026-07-21-movebank-backfill.md
@@ -1,0 +1,1307 @@
+# Movebank Backfill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an operator-triggered backfill that loads a Movebank study's full history (hundreds of thousands of records per high-frequency individual) via self-cascading per-individual sub-actions, bounded by a shared connection semaphore, meeting the steady-state pull at a clean boundary, with throttled Activity Log progress.
+
+**Architecture:** A new executable `backfill` action seeds a Redis work-queue and triggers up to K internal `backfill_individual` sub-actions (rolling queue). Each sub-action self-cascades through one individual's history in time-budgeted steps, acquiring a username-keyed Redis connection semaphore (shared with the steady-state pull and all integrations on that username) around every Movebank call, and sends to Gundi inline. Backfill covers `[start, end)`; the pull covers `[end, ∞)`; the accessory sensor gets a configurable settling margin so multi-hour-late records aren't missed.
+
+**Tech Stack:** Python 3.10, pydantic v1, redis.asyncio, movebank-client ~=1.3.1, pytest + pytest-asyncio + pytest-mock + respx. Tests run in the Docker `mb-runner-test` image.
+
+## Global Constraints
+
+- Python 3.10 only; run all tests in Docker: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app -q`. (Rebuild the image only if requirements change: `docker build -t mb-runner-test --target devimage -f docker/Dockerfile .`)
+- pydantic **v1** syntax everywhere (`validator`, `parse_obj`, `.dict()`, `Field`).
+- Branch from `sync-20260721` (or `main` if the sync PR #12 has merged). Never work on `main`.
+- New integration settings go in `app/settings/integration.py`, NOT `app/settings/base.py` (base.py syncs from the upstream template).
+- Production values, copied verbatim: `MOVEBANK_MAX_CONNECTIONS` default **25** (headroom under Movebank's 31/username); `ACCESSORY_SETTLING_HOURS` default **12**; `BACKFILL_MAX_CONCURRENCY` default **8**; cascade step time budget = **0.8 × MAX_ACTION_EXECUTION_TIME**.
+- The transform's `loaded_at` field defeats Gundi dedup, so backfill `[start, end)` and pull `[end, ∞)` MUST NOT overlap — a window fetched twice becomes duplicate observations.
+- GPS records arrive promptly (no settling margin); only accessory-measurements (sensor id 7842954) gets the settling margin.
+- Movebank event ids are ~monotonic with ingest order, so a late-arriving record has a high `event_id`; the `event_id >= minimum_event_id` filter is what makes a widened re-read safe (drops already-sent events).
+- Commit messages end with the `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer.
+
+## File Structure
+
+- `app/settings/integration.py` (MODIFY) — new settings.
+- `app/services/movebank_connections.py` (CREATE) — the username-keyed connection semaphore + `movebank_slot` async context manager.
+- `app/actions/handlers.py` (MODIFY) — adopt the semaphore in `action_pull_events_for_individual`; apply the accessory settling margin; add `action_backfill` and `action_backfill_events_for_individual`.
+- `app/actions/configurations.py` (MODIFY) — `BackfillConfig`, `BackfillEventsForIndividualConfig`.
+- `app/actions/backfill_queue.py` (CREATE) — Redis job/queue state helpers.
+- `app/actions/tests/` (CREATE/MODIFY) — tests per component.
+- `README.md` (MODIFY) — document the actions and settings.
+
+---
+
+### Task 1: Settings + connection semaphore
+
+**Files:**
+- Modify: `app/settings/integration.py`
+- Create: `app/services/movebank_connections.py`
+- Test: `app/services/tests/test_movebank_connections.py`
+
+**Interfaces:**
+- Consumes: `settings.MOVEBANK_MAX_CONNECTIONS`, `settings.REDIS_HOST/REDIS_PORT/REDIS_STATE_DB`.
+- Produces:
+  - `connection_key(username: str) -> str` — `"movebank:connections:" + sha256(username)[:16]`.
+  - `async movebank_slot(username: str, *, ttl_seconds: int = 600)` — async context manager; acquires a slot (raises `NoConnectionSlot` if the username is at capacity) and releases on exit.
+  - `class NoConnectionSlot(Exception)`.
+
+- [ ] **Step 1: Add settings**
+
+Append to `app/settings/integration.py`:
+
+```python
+# Movebank connection budget, shared across all integrations using the same
+# Movebank username (Movebank documents ~31 simultaneous connections per user).
+MOVEBANK_MAX_CONNECTIONS = env.int("MOVEBANK_MAX_CONNECTIONS", 25)
+# Accessory-measurements records can arrive at Movebank hours after their
+# timestamp; the accessory query re-reads this many hours so late arrivals are
+# caught (the event-id filter drops already-sent events, so no duplicates).
+ACCESSORY_SETTLING_HOURS = env.int("ACCESSORY_SETTLING_HOURS", 12)
+# Rolling-queue width for a backfill job: how many individuals are in flight at
+# once. Deliberately below MOVEBANK_MAX_CONNECTIONS so backfill never starves
+# the steady-state pull or other integrations on the same username.
+BACKFILL_MAX_CONCURRENCY = env.int("BACKFILL_MAX_CONCURRENCY", 8)
+```
+
+(If `app/settings/integration.py` does not already `from environs import Env` / define `env`, mirror the pattern already in `app/settings/base.py`; import `env` from there if it is exported, otherwise create a local `env = Env()`.)
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `app/services/tests/test_movebank_connections.py`:
+
+```python
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.movebank_connections import (
+    NoConnectionSlot,
+    connection_key,
+    movebank_slot,
+)
+
+
+def test_connection_key_hashes_username():
+    key = connection_key("gundi_user")
+    assert key.startswith("movebank:connections:")
+    # Plaintext username must not appear in the key.
+    assert "gundi_user" not in key
+    # Stable and same-length for any username.
+    assert key == connection_key("gundi_user")
+    assert len(connection_key("a")) == len(connection_key("a-much-longer-name"))
+
+
+@pytest.fixture
+def mock_redis(mocker):
+    client = MagicMock()
+    client.eval = AsyncMock(return_value=1)      # acquired by default
+    client.zrem = AsyncMock(return_value=1)
+    redis_module = MagicMock()
+    redis_module.Redis.return_value = client
+    mocker.patch("app.services.movebank_connections.redis", redis_module)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_movebank_slot_acquires_and_releases(mock_redis):
+    async with movebank_slot("gundi_user"):
+        pass
+    assert mock_redis.eval.await_count == 1      # acquire
+    assert mock_redis.zrem.await_count == 1      # release
+
+
+@pytest.mark.asyncio
+async def test_movebank_slot_raises_when_full(mock_redis):
+    mock_redis.eval = AsyncMock(return_value=0)  # at capacity
+    with pytest.raises(NoConnectionSlot):
+        async with movebank_slot("gundi_user"):
+            pass
+    # Nothing acquired, so nothing released.
+    assert mock_redis.zrem.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_movebank_slot_releases_on_exception(mock_redis):
+    with pytest.raises(ValueError):
+        async with movebank_slot("gundi_user"):
+            raise ValueError("boom")
+    assert mock_redis.zrem.await_count == 1      # released despite the error
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/services/tests/test_movebank_connections.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'app.services.movebank_connections'`.
+
+- [ ] **Step 4: Implement**
+
+Create `app/services/movebank_connections.py`:
+
+```python
+import hashlib
+import time
+import uuid
+from contextlib import asynccontextmanager
+
+import redis.asyncio as redis
+
+from app import settings
+
+
+class NoConnectionSlot(Exception):
+    """Raised when the Movebank connection budget for a username is exhausted."""
+
+
+# Atomic acquire: purge expired slots, then add a new slot only if under the
+# ceiling. KEYS[1]=zset key. ARGV: now, expiry, ceiling, token.
+# Returns 1 if acquired, 0 if at capacity.
+_ACQUIRE_LUA = """
+redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, ARGV[1])
+if redis.call('ZCARD', KEYS[1]) < tonumber(ARGV[3]) then
+    redis.call('ZADD', KEYS[1], ARGV[2], ARGV[4])
+    return 1
+end
+return 0
+"""
+
+
+def connection_key(username: str) -> str:
+    digest = hashlib.sha256(username.encode("utf-8")).hexdigest()[:16]
+    return f"movebank:connections:{digest}"
+
+
+def _client() -> redis.Redis:
+    return redis.Redis(
+        host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=settings.REDIS_STATE_DB
+    )
+
+
+@asynccontextmanager
+async def movebank_slot(username: str, *, ttl_seconds: int = 600):
+    """Acquire one Movebank connection slot for `username`, shared across every
+    integration on the same Redis. Raises NoConnectionSlot if at capacity.
+
+    Slots are members of a per-username sorted set scored by expiry time, so a
+    crashed holder's slot self-expires (purged on the next acquire) rather than
+    leaking the budget permanently.
+    """
+    client = _client()
+    key = connection_key(username)
+    token = str(uuid.uuid4())
+    now = time.time()
+    acquired = await client.eval(
+        _ACQUIRE_LUA, 1, key, now, now + ttl_seconds, settings.MOVEBANK_MAX_CONNECTIONS, token
+    )
+    if not acquired:
+        raise NoConnectionSlot(f"No Movebank connection slot available (limit {settings.MOVEBANK_MAX_CONNECTIONS}).")
+    try:
+        yield
+    finally:
+        await client.zrem(key, token)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/services/tests/test_movebank_connections.py -q`
+Expected: 5 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/settings/integration.py app/services/movebank_connections.py app/services/tests/test_movebank_connections.py
+git commit -m "feat: add username-keyed Movebank connection semaphore + settings"
+```
+
+---
+
+### Task 2: Adopt the semaphore + accessory settling margin in the steady-state pull
+
+**Files:**
+- Modify: `app/actions/handlers.py` (`action_pull_events_for_individual`, and the imports/constants block)
+- Test: `app/actions/tests/test_handlers.py` (append)
+
+**Interfaces:**
+- Consumes: `movebank_slot` (Task 1), `settings.ACCESSORY_SETTLING_HOURS`.
+- Produces: no new public symbol; the pull now (a) wraps each `get_individual_events_by_time` call in `movebank_slot(auth_config.username)`, and (b) for the accessory sensor, queries from `sensor_start - ACCESSORY_SETTLING_HOURS`.
+
+This is a change to shipped steady-state code. GPS behavior is unchanged (exact cursor); only accessory widens its re-read.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `app/actions/tests/test_handlers.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_pull_accessory_query_applies_settling_margin(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # An accessory-only individual with a saved cursor: the query start must be
+    # pushed back by ACCESSORY_SETTLING_HOURS so multi-hour-late records are caught.
+    from app.actions.client import IndividualState
+    from datetime import datetime, timezone
+    cursor_ts = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    state = IndividualState(individual_id="111", study_id="12345")
+    state.update_sensor_state(7842954, cursor_ts, 500)
+    mock_state_store[(str(integration.id), "pull_events_for_individual", "111")] = state.dict()
+
+    captured = {}
+
+    async def _gen(**kwargs):
+        captured.update(kwargs)
+        if False:
+            yield {}
+    mock_movebank_client.get_individual_events_by_time = _gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+
+    await action_pull_events_for_individual(
+        integration=integration,
+        action_config=_sub_action_config(individual_overrides={"sensor_type_ids": "accessory-measurements"}),
+    )
+
+    # First fetch for the accessory sensor starts >= 12h before the cursor.
+    assert captured["sensor_type_ids"] == [7842954]
+    assert captured["timestamp_start"] <= cursor_ts - timedelta(hours=12)
+
+
+@pytest.mark.asyncio
+async def test_pull_acquires_connection_slot(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    events = [_gps_event(100, "2026-01-01 10:00:00.000")]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    slot = mocker.patch("app.actions.handlers.movebank_slot")
+
+    await action_pull_events_for_individual(
+        integration=integration, action_config=_sub_action_config()
+    )
+
+    # The pull opened at least one connection under the shared semaphore.
+    assert slot.called
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_handlers.py -k "settling_margin or connection_slot" -q`
+Expected: FAIL — `settling_margin` on the assertion (start not pushed back), `connection_slot` with `AttributeError`/`ImportError` on `movebank_slot`.
+
+- [ ] **Step 3: Implement**
+
+In `app/actions/handlers.py` add to imports:
+
+```python
+from app.services.movebank_connections import movebank_slot, NoConnectionSlot
+```
+
+Add a helper near the constants block:
+
+```python
+def _query_start_for_sensor(sensor_type_id: int, sensor_start: datetime) -> datetime:
+    """Accessory-measurements can arrive hours late, so its query re-reads back
+    ACCESSORY_SETTLING_HOURS; GPS is prompt and uses its exact cursor."""
+    if sensor_type_id == MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID["accessory-measurements"]:
+        return sensor_start - timedelta(hours=settings.ACCESSORY_SETTLING_HOURS)
+    return sensor_start
+```
+
+Ensure `from app import settings` is imported in the module (add if missing). In the per-sensor fetch loop of `action_pull_events_for_individual`, wrap the fetch and apply the margin. Replace the existing per-sensor fetch block:
+
+```python
+            for sensor_type_id in sensor_type_ids:
+                sensor_start = sensor_type_timestamps[sensor_type_id]
+                if sensor_start > end_at:
+                    continue
+                query_start = _query_start_for_sensor(sensor_type_id, sensor_start)
+                async with movebank_slot(auth_config.username):
+                    async for event in mb.get_individual_events_by_time(
+                        study_id=action_config.study_id,
+                        individual_id=ind.id,
+                        timestamp_start=query_start,
+                        timestamp_end=end_at,
+                        sensor_type_ids=[sensor_type_id],
+                        minimum_event_id=minimum_event_ids[sensor_type_id],
+                    ):
+                        events.append(event)
+```
+
+(`auth_config` is already resolved in this handler via `client.get_auth_config(integration)`; if it is currently resolved after this loop, move that resolution above the loop.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_handlers.py -q`
+Expected: PASS (all existing handler tests plus the 2 new).
+
+- [ ] **Step 5: Run the full suite, then commit**
+
+```bash
+docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app -q
+git add app/actions/handlers.py app/actions/tests/test_handlers.py
+git commit -m "feat: apply connection semaphore and accessory settling margin to steady-state pull"
+```
+
+---
+
+### Task 3: Backfill configuration models
+
+**Files:**
+- Modify: `app/actions/configurations.py`
+- Test: `app/actions/tests/test_configurations.py` (append)
+
+**Interfaces:**
+- Consumes: `GenericActionConfiguration`, `ExecutableActionMixin`, `InternalActionConfiguration` from `app.actions.core`; `Individual` from `app.actions.client`.
+- Produces:
+  - `BackfillConfig(GenericActionConfiguration, ExecutableActionMixin)`: `study_id: str`, `individual_ids: Optional[List[str]] = None`, `start: Union[datetime, str]` (a datetime, or the literal `"all"`), `backfill_max_concurrency: Optional[int] = None`.
+  - `BackfillEventsForIndividualConfig(InternalActionConfiguration)`: `study_id: str`, `individual: Individual`, `job_id: str`, `start: datetime`, `end: datetime`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `app/actions/tests/test_configurations.py`:
+
+```python
+def test_backfill_config_whole_study_all_data():
+    from app.actions.configurations import BackfillConfig
+    from app.actions.core import ExecutableActionMixin
+    config = BackfillConfig(study_id="12345", start="all")
+    assert config.individual_ids is None
+    assert config.start == "all"
+    assert issubclass(BackfillConfig, ExecutableActionMixin)
+
+
+def test_backfill_config_dated_and_filtered():
+    from datetime import datetime, timezone
+    from app.actions.configurations import BackfillConfig
+    config = BackfillConfig(
+        study_id="12345",
+        individual_ids=["111", "222"],
+        start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        backfill_max_concurrency=4,
+    )
+    assert config.individual_ids == ["111", "222"]
+    assert config.start.year == 2024
+    assert config.backfill_max_concurrency == 4
+
+
+def test_backfill_individual_config_is_internal_and_roundtrips():
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from app.actions.core import InternalActionConfiguration
+    from datetime import datetime, timezone
+    cfg = BackfillEventsForIndividualConfig(
+        study_id="12345", individual=INDIVIDUAL, job_id="job-1",
+        start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        end=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    assert isinstance(cfg, InternalActionConfiguration)
+    restored = BackfillEventsForIndividualConfig.parse_obj(cfg.dict())
+    assert restored.individual.id == "111"
+    assert restored.job_id == "job-1"
+```
+
+(`INDIVIDUAL` is the fixture dict already defined at the top of `test_configurations.py`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_configurations.py -k backfill -q`
+Expected: FAIL with `ImportError: cannot import name 'BackfillConfig'`.
+
+- [ ] **Step 3: Implement**
+
+Add to `app/actions/configurations.py` (extend the imports to include `List`, `Union`, `datetime`, and `GenericActionConfiguration`):
+
+```python
+from datetime import datetime
+from typing import List, Optional, Union
+
+from app.actions.core import GenericActionConfiguration
+```
+
+```python
+class BackfillConfig(GenericActionConfiguration, ExecutableActionMixin):
+    """Operator-triggered study backfill. Executable, NOT scheduled — it must
+    not subclass PullActionConfiguration."""
+    study_id: str = Field(..., title="Movebank Study ID")
+    individual_ids: Optional[List[str]] = Field(
+        None,
+        title="Individual IDs",
+        description="Leave empty to backfill the whole study, or list specific individual IDs.",
+    )
+    start: Union[datetime, str] = Field(
+        "all",
+        title="Start",
+        description="Earliest datetime to backfill from, or 'all' to fetch from each individual's earliest record.",
+    )
+    backfill_max_concurrency: Optional[int] = Field(
+        None,
+        title="Max Concurrency",
+        description="Individuals processed in parallel. Defaults to the service's BACKFILL_MAX_CONCURRENCY.",
+    )
+
+
+class BackfillEventsForIndividualConfig(InternalActionConfiguration):
+    study_id: str
+    individual: Individual
+    job_id: str
+    start: datetime
+    end: datetime
+```
+
+- [ ] **Step 4: Run tests + full suite, then commit**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app -q`
+Expected: PASS.
+
+```bash
+git add app/actions/configurations.py app/actions/tests/test_configurations.py
+git commit -m "feat: add backfill action configuration models"
+```
+
+---
+
+### Task 4: Backfill job/queue state
+
+**Files:**
+- Create: `app/actions/backfill_queue.py`
+- Test: `app/actions/tests/test_backfill_queue.py`
+
+**Interfaces:**
+- Consumes: `IntegrationStateManager` (`app.services.state`) for its Redis client, or a dedicated `redis.asyncio` client mirroring its construction.
+- Produces a `BackfillJob` class bound to `(integration_id, job_id)`:
+  - `async seed(individual_ids: List[str], *, total: int, range_repr: str) -> None`
+  - `async next_individual() -> Optional[str]` — atomic pop from the pending list; returns None when empty.
+  - `async mark_started() -> None` / reads via `async snapshot() -> dict` (keys: `total`, `completed`, `observations_sent`, `pending_remaining`, `in_flight`, `range`).
+  - `async incr_in_flight(n: int = 1) -> int` / `async decr_in_flight() -> int`
+  - `async record_completion(observations: int) -> None` — increments `completed` and `observations_sent`.
+  - `async incr_attempts(individual_id: str) -> int` / `async is_done() -> bool` (pending empty and in_flight == 0).
+
+Use one Redis hash `backfill.{integration_id}.{job_id}.meta` for counters and a list `backfill.{integration_id}.{job_id}.pending` for the queue; `LPOP` for atomic dequeue, `HINCRBY` for counters.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `app/actions/tests/test_backfill_queue.py`:
+
+```python
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.actions.backfill_queue import BackfillJob
+
+
+@pytest.fixture
+def fake_redis():
+    # Minimal in-memory stand-in for the subset of redis.asyncio used here.
+    store = {"hash": {}, "list": []}
+
+    client = MagicMock()
+
+    async def hincrby(key, field, n):
+        store["hash"][field] = int(store["hash"].get(field, 0)) + n
+        return store["hash"][field]
+
+    async def hset(key, mapping=None, **kw):
+        store["hash"].update(mapping or kw)
+
+    async def hgetall(key):
+        return {k: str(v) for k, v in store["hash"].items()}
+
+    async def rpush(key, *vals):
+        store["list"].extend(vals)
+        return len(store["list"])
+
+    async def lpop(key):
+        return store["list"].pop(0) if store["list"] else None
+
+    async def llen(key):
+        return len(store["list"])
+
+    client.hincrby = AsyncMock(side_effect=hincrby)
+    client.hset = AsyncMock(side_effect=hset)
+    client.hgetall = AsyncMock(side_effect=hgetall)
+    client.rpush = AsyncMock(side_effect=rpush)
+    client.lpop = AsyncMock(side_effect=lpop)
+    client.llen = AsyncMock(side_effect=llen)
+    return client
+
+
+@pytest.fixture
+def job(mocker, fake_redis):
+    mocker.patch("app.actions.backfill_queue._client", return_value=fake_redis)
+    return BackfillJob("int-1", "job-1")
+
+
+@pytest.mark.asyncio
+async def test_seed_and_pop_order(job):
+    await job.seed(["a", "b", "c"], total=3, range_repr="[2024..2026)")
+    assert await job.next_individual() == "a"
+    assert await job.next_individual() == "b"
+    assert await job.next_individual() == "c"
+    assert await job.next_individual() is None
+
+
+@pytest.mark.asyncio
+async def test_in_flight_and_completion(job):
+    await job.seed(["a"], total=1, range_repr="r")
+    await job.incr_in_flight()
+    assert not await job.is_done()          # in_flight == 1
+    await job.next_individual()             # drain the queue
+    await job.record_completion(1500)
+    await job.decr_in_flight()
+    assert await job.is_done()              # pending empty AND in_flight == 0
+    snap = await job.snapshot()
+    assert snap["completed"] == 1
+    assert snap["observations_sent"] == 1500
+
+
+@pytest.mark.asyncio
+async def test_attempts_counter(job):
+    await job.seed(["a"], total=1, range_repr="r")
+    assert await job.incr_attempts("a") == 1
+    assert await job.incr_attempts("a") == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_backfill_queue.py -q`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement**
+
+Create `app/actions/backfill_queue.py`:
+
+```python
+from typing import List, Optional
+
+import redis.asyncio as redis
+
+from app import settings
+
+
+def _client() -> redis.Redis:
+    return redis.Redis(
+        host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=settings.REDIS_STATE_DB
+    )
+
+
+class BackfillJob:
+    """Redis-backed state for one backfill job: a pending work-queue of
+    individual IDs plus aggregate counters."""
+
+    def __init__(self, integration_id: str, job_id: str):
+        self.integration_id = str(integration_id)
+        self.job_id = job_id
+        self.db = _client()
+
+    @property
+    def _meta(self) -> str:
+        return f"backfill.{self.integration_id}.{self.job_id}.meta"
+
+    @property
+    def _pending(self) -> str:
+        return f"backfill.{self.integration_id}.{self.job_id}.pending"
+
+    async def seed(self, individual_ids: List[str], *, total: int, range_repr: str) -> None:
+        await self.db.hset(self._meta, mapping={
+            "total": total, "completed": 0, "observations_sent": 0,
+            "in_flight": 0, "range": range_repr,
+        })
+        if individual_ids:
+            await self.db.rpush(self._pending, *individual_ids)
+
+    async def next_individual(self) -> Optional[str]:
+        value = await self.db.lpop(self._pending)
+        if value is None:
+            return None
+        return value.decode() if isinstance(value, bytes) else value
+
+    async def incr_in_flight(self, n: int = 1) -> int:
+        return await self.db.hincrby(self._meta, "in_flight", n)
+
+    async def decr_in_flight(self) -> int:
+        return await self.db.hincrby(self._meta, "in_flight", -1)
+
+    async def record_completion(self, observations: int) -> None:
+        await self.db.hincrby(self._meta, "completed", 1)
+        await self.db.hincrby(self._meta, "observations_sent", observations)
+
+    async def incr_attempts(self, individual_id: str) -> int:
+        return await self.db.hincrby(self._meta, f"attempts.{individual_id}", 1)
+
+    async def is_done(self) -> bool:
+        remaining = await self.db.llen(self._pending)
+        snap = await self.snapshot()
+        return remaining == 0 and snap["in_flight"] == 0
+
+    async def snapshot(self) -> dict:
+        raw = await self.db.hgetall(self._meta)
+        data = {(k.decode() if isinstance(k, bytes) else k):
+                (v.decode() if isinstance(v, bytes) else v) for k, v in raw.items()}
+        return {
+            "total": int(data.get("total", 0)),
+            "completed": int(data.get("completed", 0)),
+            "observations_sent": int(data.get("observations_sent", 0)),
+            "in_flight": int(data.get("in_flight", 0)),
+            "range": data.get("range", ""),
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass, then commit**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_backfill_queue.py -q`
+Expected: 3 passed.
+
+```bash
+git add app/actions/backfill_queue.py app/actions/tests/test_backfill_queue.py
+git commit -m "feat: add backfill job/queue Redis state"
+```
+
+---
+
+### Task 5: `backfill` action — resolve targets, seed queue, dispatch first wave
+
+**Files:**
+- Modify: `app/actions/handlers.py`
+- Test: `app/actions/tests/test_handlers.py` (append)
+
+**Interfaces:**
+- Consumes: `BackfillConfig`, `BackfillEventsForIndividualConfig` (Task 3), `BackfillJob` (Task 4), `trigger_action`, `client.get_auth_config`, `client.MovebankClient`, `generate_individuals`, `settings.BACKFILL_MAX_CONCURRENCY`.
+- Produces: `action_backfill(integration, action_config: BackfillConfig) -> dict` returning `{"job_id": str, "individuals": int, "dispatched": int}`. Registered as action id `backfill` (executable). Uses a fixed `job_id` derived from inputs (see below) so a redelivered command doesn't start a second job.
+
+`end` resolution and `start="all"` resolution live here (Task 6 covers the per-sensor detail inside the sub-action; this task resolves the per-individual `[start, end)` pair and freezes it into each `BackfillEventsForIndividualConfig`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `app/actions/tests/test_handlers.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_backfill_seeds_queue_and_dispatches_up_to_k(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    from app.actions.configurations import BackfillConfig
+    rows = [{**INDIVIDUAL_ROW, "id": str(i)} for i in range(5)]
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=rows)
+    seen = {}
+
+    async def fake_seed(self, individual_ids, *, total, range_repr):
+        seen["seeded"] = list(individual_ids); seen["total"] = total
+    async def fake_next(self):
+        return seen["seeded"].pop(0) if seen.get("seeded") else None
+    async def fake_incr(self, n=1):
+        return n
+    mocker.patch("app.actions.backfill_queue.BackfillJob.seed", fake_seed)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", fake_next)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.incr_in_flight", fake_incr)
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+    mocker.patch("app.actions.handlers.settings.BACKFILL_MAX_CONCURRENCY", 3)
+
+    result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all"),
+    )
+
+    assert result["individuals"] == 5
+    assert result["dispatched"] == 3            # K, not all 5
+    assert mock_trigger.await_count == 3
+    _, kwargs = mock_trigger.await_args_list[0]
+    assert kwargs["action_id"] == "backfill_events_for_individual"
+    assert kwargs["config"].job_id == result["job_id"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_respects_individual_filter(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    from app.actions.configurations import BackfillConfig
+    rows = [{**INDIVIDUAL_ROW, "id": str(i)} for i in range(5)]
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=rows)
+    captured = {}
+    async def fake_seed(self, individual_ids, *, total, range_repr):
+        captured["ids"] = list(individual_ids)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.seed", fake_seed)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.incr_in_flight", AsyncMock(return_value=1))
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all", individual_ids=["2", "4"]),
+    )
+    assert set(captured["ids"]) == {"2", "4"}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_handlers.py -k backfill_seeds -q`
+Expected: FAIL with `ImportError: cannot import name 'action_backfill'`.
+
+- [ ] **Step 3: Implement**
+
+In `app/actions/handlers.py` add imports:
+
+```python
+import hashlib
+from typing import Optional
+from app.actions.backfill_queue import BackfillJob
+from app.actions.configurations import BackfillConfig, BackfillEventsForIndividualConfig
+```
+
+Add constants near the existing block:
+
+```python
+BACKFILL_ACTION_ID = "backfill_events_for_individual"
+BACKFILL_WATERMARK_ACTION_ID = "backfill_watermark"
+BACKFILL_PROGRESS_THROTTLE_SECONDS = 300
+```
+
+Add the handler:
+
+```python
+def _resolve_start(start, ind) -> datetime:
+    """A concrete datetime for this individual: the operator's date, or for
+    'all' the individual's earliest record (falling back to the lookback floor)."""
+    if isinstance(start, datetime):
+        return start
+    # start == "all"
+    if ind.timestamp_start:
+        return ind.timestamp_start
+    return datetime.now(tz=timezone.utc) - timedelta(days=3650)  # ~10y floor
+
+
+async def _resolve_end(integration_id: str, ind, now: datetime) -> datetime:
+    """Freeze the boundary where backfill meets the steady-state pull: the
+    individual's existing pull cursor if any, else now (and the pull is seeded
+    to now by the individual sub-action on completion)."""
+    saved = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
+    if saved:
+        state = IndividualState.parse_obj(saved)
+        stamps = [s.latest_timestamp for s in state.sensor_states.values() if s.latest_timestamp]
+        if stamps:
+            return min(stamps)
+    return now
+
+
+@activity_logger()
+async def action_backfill(integration, action_config: BackfillConfig):
+    integration_id = str(integration.id)
+    now = datetime.now(tz=timezone.utc)
+    auth_config = client.get_auth_config(integration)
+    mb_client = client.MovebankClient(
+        base_url=integration.base_url,
+        username=auth_config.username,
+        password=auth_config.password.get_secret_value(),
+    )
+    async with mb_client as mb:
+        rows = await mb.get_individuals_by_study(study_id=action_config.study_id)
+    individuals = list(generate_individuals(rows))
+    if action_config.individual_ids:
+        wanted = set(action_config.individual_ids)
+        individuals = [i for i in individuals if i.id in wanted]
+
+    # Deterministic job id: a redelivered backfill command resumes the same job.
+    job_seed = f"{action_config.study_id}:{sorted(i.id for i in individuals)}:{action_config.start}"
+    job_id = "job-" + hashlib.sha256(job_seed.encode()).hexdigest()[:12]
+    job = BackfillJob(integration_id, job_id)
+
+    ranges = {i.id: (_resolve_start(action_config.start, i), await _resolve_end(integration_id, i, now)) for i in individuals}
+    # Only individuals with a non-empty range are worth queuing.
+    queued = [i for i in individuals if ranges[i.id][0] < ranges[i.id][1]]
+    range_repr = f"[{action_config.start} .. {now.isoformat()})"
+    await job.seed([i.id for i in queued], total=len(queued), range_repr=range_repr)
+
+    logger.info(f"Backfill {job_id} for study {action_config.study_id}: {len(queued)} individuals, range {range_repr}")
+
+    k = action_config.backfill_max_concurrency or settings.BACKFILL_MAX_CONCURRENCY
+    by_id = {i.id: i for i in queued}
+    dispatched = 0
+    while dispatched < k:
+        next_id = await job.next_individual()
+        if next_id is None:
+            break
+        ind = by_id[next_id]
+        start_dt, end_dt = ranges[next_id]
+        await job.incr_in_flight()
+        await trigger_action(
+            integration_id=integration_id,
+            action_id=BACKFILL_ACTION_ID,
+            config=BackfillEventsForIndividualConfig(
+                study_id=action_config.study_id, individual=ind,
+                job_id=job_id, start=start_dt, end=end_dt,
+            ),
+        )
+        dispatched += 1
+
+    return {"job_id": job_id, "individuals": len(queued), "dispatched": dispatched}
+```
+
+- [ ] **Step 4: Run tests + full suite, then commit**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app -q`
+Expected: PASS.
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_handlers.py
+git commit -m "feat: add backfill action that seeds the queue and dispatches the first wave"
+```
+
+---
+
+### Task 6: `backfill_events_for_individual` sub-action — cascade, hand-off, dispatch-next
+
+**Files:**
+- Modify: `app/actions/handlers.py`
+- Test: `app/actions/tests/test_handlers.py` (append)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–5 plus `build_observation`, `chunks`, `send_observations_to_gundi`, `_ensure_utc`, `_query_start_for_sensor`, `movebank_slot`, `MAX_ACTION_EXECUTION_TIME`.
+- Produces: `action_backfill_events_for_individual(integration, action_config: BackfillEventsForIndividualConfig) -> dict`. Registered internal action `backfill_events_for_individual`. On each invocation it does one time-bounded cascade step over `[watermark, end)`; if the watermark reaches `end` it finalizes (writes the steady-state pull cursor from the backfill watermark, records completion, dispatches the next queued individual); otherwise it re-triggers itself.
+
+The backfill watermark is stored under action id `BACKFILL_WATERMARK_ACTION_ID` with `source_id = f"{job_id}.{individual_id}"`, reusing the `IndividualState` model. The step uses a time deadline `time.monotonic() + 0.8 * MAX_ACTION_EXECUTION_TIME`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `app/actions/tests/test_handlers.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_backfill_individual_finalizes_and_dispatches_next(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from app.actions.client import IndividualState
+    from datetime import datetime, timezone
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 3, tzinfo=timezone.utc)
+    # One small window of GPS events fully inside [start, end): the step reaches
+    # `end` in a single pass and finalizes.
+    events = [_gps_event(10, "2024-01-02 00:00:00.000")]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 1, "in_flight": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "completed"
+    # The steady-state pull cursor was written from the backfill watermark (ts + event id).
+    handed = mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
+    st = IndividualState.parse_obj(handed)
+    assert st.get_sensor_state(653).highest_event_id == 10
+    # Queue empty -> no next dispatch.
+    assert not mock_trigger.called
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_retriggers_self_when_budget_exhausted(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from datetime import datetime, timezone
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 1, 1, tzinfo=timezone.utc)   # huge range
+    events = [_gps_event(i, "2024-01-02 00:00:00.000") for i in range(3)]
+    mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    # Force the time budget to zero so the step stops after the first window.
+    mocker.patch("app.actions.handlers.settings.MAX_ACTION_EXECUTION_TIME", 0)
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "continued"
+    # It re-triggered ITSELF (same individual), not the next one.
+    assert mock_trigger.await_count == 1
+    _, kwargs = mock_trigger.await_args_list[0]
+    assert kwargs["action_id"] == "backfill_events_for_individual"
+    assert kwargs["config"].individual.id == "111"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_handlers.py -k backfill_individual -q`
+Expected: FAIL with `ImportError: cannot import name 'action_backfill_events_for_individual'`.
+
+- [ ] **Step 3: Implement**
+
+Add `import time` to `app/actions/handlers.py` if not present, then add the handler:
+
+```python
+@activity_logger()
+async def action_backfill_events_for_individual(integration, action_config: BackfillEventsForIndividualConfig):
+    ind = action_config.individual
+    integration_id = str(integration.id)
+    job = BackfillJob(integration_id, action_config.job_id)
+    watermark_source = f"{action_config.job_id}.{ind.id}"
+    log_reference = f"job:{action_config.job_id},individual:{ind.id}"
+
+    sensor_type_labels = [label.strip().lower() for label in ind.sensor_type_ids.split(",")]
+    sensor_type_ids = [
+        MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID[label]
+        for label in sensor_type_labels
+        if label in MovebankClient.MOVEBANK_SENSOR_TYPE_LABEL_TO_ID
+    ]
+    if not sensor_type_ids:
+        return await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
+
+    saved = await state_manager.get_state(integration_id, BACKFILL_WATERMARK_ACTION_ID, source_id=watermark_source)
+    state = IndividualState.parse_obj(saved) if saved else IndividualState(
+        individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
+    )
+    sensor_type_timestamps, minimum_event_ids = {}, {}
+    for stid in sensor_type_ids:
+        ss = state.get_sensor_state(stid)
+        sensor_type_timestamps[stid] = ss.latest_timestamp or action_config.start
+        minimum_event_ids[stid] = (ss.highest_event_id or 0) + 1
+
+    auth_config = client.get_auth_config(integration)
+    deadline = time.monotonic() + 0.8 * settings.MAX_ACTION_EXECUTION_TIME
+    window = DEFAULT_BATCH_WINDOW
+    observations_sent = 0
+    current = min(sensor_type_timestamps.values())
+
+    mb_client = client.MovebankClient(
+        base_url=integration.base_url, username=auth_config.username,
+        password=auth_config.password.get_secret_value(),
+    )
+    async with mb_client as mb:
+        while current < action_config.end and time.monotonic() < deadline:
+            end_at = min(action_config.end, current + window)
+            events = []
+            for stid in sensor_type_ids:
+                sensor_start = sensor_type_timestamps[stid]
+                if sensor_start > end_at:
+                    continue
+                query_start = _query_start_for_sensor(stid, sensor_start)
+                async with movebank_slot(auth_config.username):
+                    async for event in mb.get_individual_events_by_time(
+                        study_id=action_config.study_id, individual_id=ind.id,
+                        timestamp_start=query_start, timestamp_end=end_at,
+                        sensor_type_ids=[stid], minimum_event_id=minimum_event_ids[stid],
+                    ):
+                        events.append(event)
+
+            device_name = ind.nick_name or ind.local_identifier or ind.ring_id
+            observations = [o for e in events if (o := build_observation(event=e, device_name=device_name)) is not None]
+            for batch in chunks(observations, OBSERVATIONS_BATCH_SIZE):
+                await send_observations_to_gundi(observations=batch, integration_id=integration_id)
+
+            _advance_watermarks(state, events, sensor_type_ids, sensor_type_timestamps, minimum_event_ids)
+            observations_sent += len(observations)
+            current = current + window
+            await state_manager.set_state(integration_id, BACKFILL_WATERMARK_ACTION_ID,
+                                          json.loads(state.json()), source_id=watermark_source)
+
+    if current < action_config.end:
+        # Budget exhausted mid-range: continue THIS individual on the next step.
+        await trigger_action(
+            integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=action_config,
+        )
+        logger.info(f"Backfill {log_reference} continued at {current.isoformat()} ({observations_sent} obs this step)")
+        return {"status": "continued", "observations_sent": observations_sent}
+
+    return await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=observations_sent, state=state)
+```
+
+Add the two helpers. `_advance_watermarks` is the per-sensor cursor logic factored out of the steady-state handler (extract it there too so both call one function — DRY):
+
+```python
+def _advance_watermarks(state, events, sensor_type_ids, sensor_type_timestamps, minimum_event_ids):
+    events_by_sensor = {}
+    for e in events:
+        try:
+            events_by_sensor.setdefault(int(e.get("sensor_type_id")), []).append(e)
+        except (TypeError, ValueError):
+            continue
+    for stid in sensor_type_ids:
+        se = events_by_sensor.get(stid, [])
+        stamps, ids = [], []
+        for e in se:
+            try:
+                stamps.append(_ensure_utc(parse_date(e.get("timestamp"))))
+            except Exception:
+                pass
+            try:
+                ids.append(int(e.get("event_id")))
+            except (TypeError, ValueError):
+                pass
+        if stamps or ids:
+            new_latest = max(stamps) if stamps else sensor_type_timestamps[stid]
+            new_max = max(ids) if ids else minimum_event_ids[stid] - 1
+            state.update_sensor_state(stid, new_latest, new_max)
+            sensor_type_timestamps[stid] = new_latest
+            minimum_event_ids[stid] = new_max + 1
+
+
+async def _finalize_backfill_individual(integration_id, job, ind, action_config, *, observations, state=None):
+    # Hand off the FULL cursor (timestamp + highest event id per sensor) to the
+    # steady-state pull, so the pull's event-id filter absorbs the accessory
+    # settling re-read at the boundary without re-emitting backfilled events.
+    if state is not None:
+        existing = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
+        if not existing:
+            await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
+                                          json.loads(state.json()), source_id=ind.id)
+    await job.record_completion(observations)
+    await job.decr_in_flight()
+
+    if await job.is_done():
+        snap = await job.snapshot()
+        logger.info(f"Backfill {action_config.job_id} finished: {snap['completed']}/{snap['total']} "
+                    f"individuals, {snap['observations_sent']} observations")
+    else:
+        if await state_manager.set_if_absent(
+            integration_id, f"backfill_progress.{action_config.job_id}", ttl_seconds=BACKFILL_PROGRESS_THROTTLE_SECONDS
+        ):
+            snap = await job.snapshot()
+            logger.info(f"Backfill {action_config.job_id} progress: {snap['completed']}/{snap['total']} "
+                        f"individuals, ~{snap['observations_sent']} observations")
+        next_id = await job.next_individual()
+        if next_id is not None:
+            await _dispatch_backfill_individual(integration_id, job, action_config, next_id)
+
+    return {"status": "completed", "observations_sent": observations}
+```
+
+`_dispatch_backfill_individual` re-fetches the next individual's `Individual` and range. Because the sub-action does not carry the whole study roster, store each queued individual's `(row, start, end)` in job state at seed time is heavier than needed; instead the next individual's config is reconstructed from the study lookup is too slow here. Simplest correct approach: the `backfill` action (Task 5) writes a per-individual config blob to Redis at seed time, and dispatch reads it. Add to Task 4's `BackfillJob`:
+
+```python
+    async def put_individual_config(self, individual_id: str, config_json: str) -> None:
+        await self.db.hset(f"{self._meta}.configs", mapping={individual_id: config_json})
+
+    async def get_individual_config(self, individual_id: str) -> Optional[str]:
+        raw = await self.db.hget(f"{self._meta}.configs", individual_id)
+        return (raw.decode() if isinstance(raw, bytes) else raw) if raw else None
+```
+
+Then in Task 5, after computing each queued individual's range, also call `await job.put_individual_config(i.id, BackfillEventsForIndividualConfig(...).json())`, and `_dispatch_backfill_individual` becomes:
+
+```python
+async def _dispatch_backfill_individual(integration_id, job, action_config, individual_id):
+    blob = await job.get_individual_config(individual_id)
+    if blob is None:
+        logger.warning(f"Backfill {action_config.job_id}: no stored config for individual {individual_id}; skipping")
+        return
+    cfg = BackfillEventsForIndividualConfig.parse_raw(blob)
+    await job.incr_in_flight()
+    await trigger_action(integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=cfg)
+```
+
+(Task 5's first-wave dispatch loop should use `_dispatch_backfill_individual` too, so config storage/read is the single dispatch path. Update Task 5's loop accordingly when implementing this task, and add a `put_individual_config` call for every queued individual before the dispatch loop.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_handlers.py -k backfill -q`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite + commit**
+
+```bash
+docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app -q
+git add app/actions/handlers.py app/actions/backfill_queue.py app/actions/tests/
+git commit -m "feat: add self-cascading backfill sub-action with boundary hand-off and rolling dispatch"
+```
+
+---
+
+### Task 7: Error handling — abandon-after-retries, connection backoff, one-job guard
+
+**Files:**
+- Modify: `app/actions/handlers.py`
+- Test: `app/actions/tests/test_handlers.py` (append)
+
+**Interfaces:**
+- Consumes: `BackfillJob.incr_attempts`, `NoConnectionSlot`.
+- Produces: `BACKFILL_MAX_ATTEMPTS = 5` constant; the sub-action catches `NoConnectionSlot` → re-triggers itself (backoff, no work lost); catches other exceptions → increments attempts, and once attempts exceed the max, logs a warning, records the individual done-with-error (decrement in-flight, dispatch next) so the job still drains.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `app/actions/tests/test_handlers.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_backfill_individual_backs_off_when_no_slot(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from app.services.movebank_connections import NoConnectionSlot
+    from datetime import datetime, timezone
+    def _raise(*a, **k):
+        raise NoConnectionSlot("full")
+    mocker.patch("app.actions.handlers.movebank_slot", _raise)
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1",
+            start=datetime(2024, 1, 1, tzinfo=timezone.utc), end=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ),
+    )
+    assert result["status"] == "backoff"
+    # Re-triggered self to retry later; did not finalize.
+    assert mock_trigger.await_count == 1
+    assert mock_trigger.await_args_list[0].kwargs["config"].individual.id == "111"
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_abandoned_after_max_attempts(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    from datetime import datetime, timezone
+    mock_movebank_client.get_individual_events_by_time = mocker.MagicMock(side_effect=RuntimeError("mb down"))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.incr_attempts", AsyncMock(return_value=6))  # over the max
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0, "in_flight": 0, "range": "r"}))
+    warn = mocker.patch("app.actions.handlers.logger.warning")
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1",
+            start=datetime(2024, 1, 1, tzinfo=timezone.utc), end=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ),
+    )
+    assert result["status"] == "abandoned"
+    assert warn.called
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_handlers.py -k "no_slot or abandoned" -q`
+Expected: FAIL (statuses not implemented).
+
+- [ ] **Step 3: Implement**
+
+Add `BACKFILL_MAX_ATTEMPTS = 5` to the constants block. Wrap the sub-action body from Task 6 so the fetch/send loop is inside a `try`. Structure:
+
+```python
+async def action_backfill_events_for_individual(integration, action_config: BackfillEventsForIndividualConfig):
+    ind = action_config.individual
+    integration_id = str(integration.id)
+    job = BackfillJob(integration_id, action_config.job_id)
+    try:
+        # ... the Task 6 body: build watermark, cascade loop, then either
+        # re-trigger self ("continued") or _finalize_backfill_individual ("completed") ...
+        ...
+    except NoConnectionSlot:
+        await trigger_action(integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=action_config)
+        logger.info(f"Backfill {action_config.job_id}/{ind.id}: no connection slot, backing off")
+        return {"status": "backoff"}
+    except Exception as exc:
+        attempts = await job.incr_attempts(ind.id)
+        if attempts <= BACKFILL_MAX_ATTEMPTS:
+            await trigger_action(integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=action_config)
+            logger.info(f"Backfill {action_config.job_id}/{ind.id}: attempt {attempts} failed ({exc}); retrying")
+            return {"status": "retry", "attempts": attempts}
+        logger.warning(f"Backfill {action_config.job_id}/{ind.id}: abandoned after {attempts} attempts: {exc}")
+        result = await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
+        return {"status": "abandoned", **{k: v for k, v in result.items() if k != "status"}}
+```
+
+Note: the `NoConnectionSlot` re-trigger must NOT double-count in-flight (the individual is still the same in-flight unit), and the abandon path calls `_finalize_backfill_individual` which decrements in-flight and dispatches next — consistent with normal completion.
+
+- [ ] **Step 4: Run tests + full suite, then commit**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app -q`
+Expected: PASS.
+
+```bash
+git add app/actions/handlers.py app/actions/tests/test_handlers.py
+git commit -m "feat: backfill error handling — connection backoff, abandon-after-retries"
+```
+
+---
+
+### Task 8: Final verification, docs, PR
+
+**Files:**
+- Modify: `README.md`
+- Test: clean-build full suite + discovery check
+
+**Interfaces:** none — verification and delivery.
+
+- [ ] **Step 1: Clean build + full suite**
+
+```bash
+docker build -t mb-runner-test --target devimage -f docker/Dockerfile .
+docker run --rm mb-runner-test python -m pytest app -q
+```
+Expected: PASS (no volume mount — verifies the committed tree).
+
+- [ ] **Step 2: Verify action discovery**
+
+```bash
+docker run --rm mb-runner-test python -c "
+from app.actions import action_handlers
+from app.actions.core import InternalActionConfiguration, ExecutableActionMixin
+print('actions:', sorted(action_handlers.keys()))
+_, backfill_cfg, _ = action_handlers['backfill']
+_, sub_cfg, _ = action_handlers['backfill_events_for_individual']
+print('backfill executable:', issubclass(backfill_cfg, ExecutableActionMixin))
+print('sub-action internal:', issubclass(sub_cfg, InternalActionConfiguration))
+"
+```
+Expected: actions include `auth`, `pull_observations`, `pull_events_for_individual`, `backfill`, `backfill_events_for_individual`; backfill executable True; sub-action internal True.
+
+- [ ] **Step 3: Update README**
+
+Add a "Backfill" subsection under the existing Actions section:
+
+```markdown
+- **backfill** (executable) — operator-triggered historical load for a study.
+  Config: `study_id`, optional `individual_ids` (whole study if empty), `start`
+  (a datetime or `"all"`), optional `backfill_max_concurrency`. Seeds a rolling
+  work-queue and dispatches per-individual sub-actions.
+- **backfill_events_for_individual** (internal) — self-cascading worker for one
+  individual: fetches `[start, end)` in time-budgeted steps under the shared
+  Movebank connection semaphore, sends to Gundi, and on completion hands the
+  full `(timestamp, event_id)` cursor to `pull_events_for_individual` so
+  steady-state collection continues without a gap or duplicates.
+
+### Settings
+
+- `MOVEBANK_MAX_CONNECTIONS` (default 25) — shared per-username Movebank
+  connection ceiling (Movebank allows ~31).
+- `ACCESSORY_SETTLING_HOURS` (default 12) — how far back accessory-measurements
+  queries re-read, since those records can arrive hours late.
+- `BACKFILL_MAX_CONCURRENCY` (default 8) — individuals in flight per backfill job.
+```
+
+- [ ] **Step 4: Commit, push, open PR**
+
+```bash
+git add README.md
+git commit -m "docs: document backfill actions and settings"
+git push -u origin <branch>
+gh pr create --repo PADAS/gundi-integration-movebank --base main \
+  --title "Add Movebank study backfill" \
+  --body "Operator-triggered backfill for full study history. Cascading per-individual sub-actions bounded by a shared per-username connection semaphore (25, under Movebank's 31); rolling queue of 8 in flight; time-budgeted cascade steps; accessory-measurements settling margin (12h) so multi-hour-late records aren't missed; full-cursor hand-off to the steady-state pull at a no-overlap boundary; throttled Activity Log progress. See docs/superpowers/specs/2026-07-21-movebank-backfill-design.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Notes for the implementer
+
+- **Task 6 is the big one** and depends on a small addition to Task 4's `BackfillJob` (`put_individual_config`/`get_individual_config`) and a rework of Task 5's dispatch loop to go through `_dispatch_backfill_individual`. When executing Task 6, make those two edits as part of it and re-run Tasks 4 and 5's tests to confirm no regression.
+- **DRY the watermark logic**: `_advance_watermarks` should be extracted from the existing `action_pull_events_for_individual` (Task 6 step 3) and called by both handlers, not duplicated.
+- The `NoConnectionSlot` backoff currently re-triggers immediately; if churn is observed in the stage smoke test, add a jittered delay marker to the command (out of scope here, noted for follow-up).

--- a/docs/superpowers/specs/2026-07-21-movebank-backfill-design.md
+++ b/docs/superpowers/specs/2026-07-21-movebank-backfill-design.md
@@ -148,7 +148,7 @@ Job metadata (Redis, per `job_id`) drives Activity Log records via the existing 
 - **Transient Movebank errors** (429/5xx/timeouts): the client already retries with bounded backoff; a step that still fails re-triggers itself up to a bounded `attempts` counter in job state, then logs the abandon warning and removes the individual from `in_flight` (dequeuing the next so the job keeps progressing).
 - **Semaphore leak protection**: slot TTL (above) plus `finally`-release.
 - **At-least-once redelivery**: watermark advancement is idempotent (a redelivered step re-fetches from the same watermark; the event-id filter dedups), and queue hand-off uses atomic Redis ops so an individual is not double-dequeued or double-triggered.
-- **One active job per integration**: re-triggering `backfill` while a job is in flight is guarded (new job refused, or explicitly supersedes) rather than clobbering live job state. A fresh `job_id` per accepted run.
+- **Job identity / redelivery**: the `job_id` is derived deterministically from `(study_id, individual set, start)`, so a redelivered `backfill` command resumes the same job rather than starting a second. A stricter guard that *refuses a concurrent distinct backfill* is deferred: the connection semaphore already bounds the shared Movebank resource, so two jobs at once are safe (bounded by `MOVEBANK_MAX_CONNECTIONS`) if impolite. Listed in Deferred.
 - **`MAX_ACTION_EXECUTION_TIME` retuning**: the step time budget is derived as ≈80% of the setting, so it tracks changes to the ack deadline.
 
 ## Testing
@@ -168,3 +168,5 @@ All in the Docker `mb-runner-test` image, `respx`-mocked Movebank, mocked Redis/
 - A dedicated progress surface in the Gundi UI (Activity Log records for now).
 - Cross-username coordination (semaphore is per-username; different usernames are independent budgets).
 - Sensor types beyond GPS and accessory-measurements.
+- Refusing concurrent *distinct* backfill jobs for one integration (redelivery of the same job is handled via the deterministic `job_id`; the semaphore keeps concurrent jobs safe, so a hard guard is a follow-up).
+- Jittered delay on the `NoConnectionSlot` backoff re-trigger (immediate re-trigger for now; add a delay marker if stage smoke-testing shows churn).

--- a/docs/superpowers/specs/2026-07-21-movebank-backfill-design.md
+++ b/docs/superpowers/specs/2026-07-21-movebank-backfill-design.md
@@ -1,0 +1,170 @@
+# Movebank Backfill — Design
+
+**Status:** approved design, pre-implementation
+**Date:** 2026-07-21
+
+## Goal
+
+Let an operator backfill the full history of a Movebank study — potentially hundreds of thousands of observations per individual for high-frequency trackers (e.g. vultures) spanning months or years — without exceeding Movebank's connection limits, without stalling steady-state collection, and with visible progress in the Gundi Activity Log.
+
+This repo is not yet in production, so the actions and configuration may be reshaped freely.
+
+## Background: the current pull
+
+- `pull_observations` (scheduled `*/10`) lists a study's individuals and triggers one internal `pull_events_for_individual` sub-action each.
+- `pull_events_for_individual` keeps a **per-sensor cursor** (`latest_timestamp`, `highest_event_id`) in Redis per individual, fetches events in adaptive time windows, transforms them, and sends to Gundi in batches. A per-run record cap (`MAXIMUM_RECORDS_PER_INDIVIDUAL = 2000`) stops each run between windows; the next scheduled tick continues from the saved cursor.
+- The `movebank-client` applies a **60-minute look-back overlap** on accessory-measurements queries to catch mildly out-of-order data; the `event_id >= minimum_event_id` filter prevents the overlap from re-emitting already-seen events.
+
+Backfilling large history through this path alone is too slow (≈2000 records / individual / 10 min, schedule-paced) and has no progress signal or trigger UX. This design adds a dedicated backfill capability on top of the same primitives.
+
+## Key decisions (from brainstorming)
+
+1. **Inline, no GCS.** Backfill reads from Movebank and sends to Gundi in batches directly, like the current pull. No storage-decoupling layer. Revisit only if Gundi-side throughput becomes the bottleneck.
+2. **Shared connection semaphore.** All integrations sharing a Movebank username share one Redis instance, so a username-keyed Redis semaphore enforces the real connection limit across every integration and every action.
+3. **Separate backfill action.** A distinct operator-triggered `backfill` action runs its own self-cascading sub-actions; the `*/10` incremental pull is unchanged and independent. Both share the cascade engine and the semaphore.
+4. **Time-budget cascade step.** A cascade step runs until ≈80% of `MAX_ACTION_EXECUTION_TIME`, then persists its watermark and re-triggers itself; a record/window backstop guards pathological cases.
+5. **Study-wide + optional individual filter.** Default backfills the whole study; an optional individual-ID list narrows it. `start` = a date or an "all data" sentinel; `end` is frozen per individual so backfill meets the pull with no gap or overlap.
+6. **Bounded rolling queue (dispatcher B).** The job keeps `K` individuals in flight (`backfill_max_concurrency`, below the semaphore ceiling); each finishing individual dequeues and triggers the next.
+7. **Throttled job-level progress** in the Activity Log — start, throttled aggregate, complete, plus a warning when an individual is abandoned.
+8. **Full-cursor hand-off + accessory settling margin** at the boundary (see below).
+
+## Architecture
+
+### Components
+
+- **`backfill` action** (executable; `ExecutableActionMixin` so the portal shows a Run button). Resolves target individuals, computes each one's `[start, end)` range, writes the job's Redis work-queue and metadata, logs "started," and triggers the first `K` `backfill_individual` sub-actions.
+- **`backfill_individual` sub-action** (internal; `InternalActionConfiguration`). Self-cascading worker for one individual: fetch from its backfill watermark toward `end` in per-sensor windows, send to Gundi, advance watermark, bounded by the time budget. On budget exhaustion → re-trigger self. On reaching `end` → finalize (hand off cursor), then dequeue + trigger the next individual.
+- **Connection semaphore** (`app/services/movebank_connections.py`, new). `async with movebank_slot(username):` around every Movebank connection, adopted by **both** backfill and the steady-state pull.
+
+### Data flow
+
+```
+operator → backfill action
+  ├─ resolve individuals (whole study | filter list)
+  ├─ per individual: compute [start, end)
+  ├─ Redis: pending-queue = [individuals], in_flight = 0, counters = 0
+  ├─ log "backfill started (N individuals, range)"
+  └─ trigger K × backfill_individual
+
+backfill_individual (per individual, cascading)
+  loop within time budget:
+    for each sensor:
+      async with movebank_slot(username):   ← hard cap across all integrations,
+        fetch window [watermark, min(watermark+window, end))    held around each
+                                                                Movebank connection
+    transform + send to Gundi (batches of OBSERVATIONS_BATCH_SIZE)
+    advance per-sensor backfill watermark (timestamp + highest_event_id)
+  if watermark < end:  re-trigger self          (continue this individual)
+  else:                finalize + dequeue next   (individual done)
+     ├─ write steady-state pull cursor = (watermark_ts, highest_event_id) per sensor
+     ├─ Redis: in_flight--, completed++, pop next from pending
+     ├─ throttled: log "Y/N complete, ~M observations"
+     ├─ if next: trigger backfill_individual(next)
+     └─ if queue empty and in_flight == 0: log "backfill finished"
+```
+
+## Action & config surfaces
+
+```python
+# Executable but NOT a scheduled pull: it must not subclass PullActionConfiguration
+# (that would register it for type-wide scheduling). Operator-triggered only.
+class BackfillConfig(GenericActionConfiguration, ExecutableActionMixin):
+    study_id: str
+    individual_ids: Optional[List[str]] = None          # empty/None = whole study
+    start: Union[datetime, Literal["all"]]               # date, or "all data"
+    backfill_max_concurrency: int = 8                    # rolling-queue width (K)
+
+class BackfillIndividualConfig(InternalActionConfiguration):
+    study_id: str
+    individual: Individual
+    job_id: str
+    start: datetime                                      # resolved (no "all" sentinel here)
+    end: datetime                                        # frozen boundary
+```
+
+- `PullObservationsConfig` / `PullEventsForIndividualConfig` are unchanged. The old `maximum_lookback_hours`-override manual-backfill hack is removed — `backfill` replaces it.
+- `end` is resolved per individual at job start (see boundary section); `start="all"` resolves to the individual's Movebank `timestamp_start` (falling back to a floor if absent).
+
+## Concurrency
+
+### Global connection semaphore (correctness guarantee)
+
+- Redis key `movebank:connections:<username_hash>` where `<username_hash>` = truncated SHA-256 of the username (avoids storing the plaintext account name in a key).
+- Ceiling: `MOVEBANK_MAX_CONNECTIONS` setting, default **25** (headroom under Movebank's documented 31/username).
+- Acquire = atomic `INCR`; if result > ceiling, `DECR` and report "no slot." Release = `DECR`, always in `finally`.
+- Each slot key/counter carries a **TTL** (a few × the step time budget) so a crashed worker cannot leak a slot permanently.
+- When no slot is available, a worker does **not** spin: it re-triggers itself with a jittered delay marker and returns, freeing its execution slot.
+- **The steady-state `pull_events_for_individual` adopts the same `movebank_slot` context manager**, so backfill and ongoing collection draw from one shared budget.
+
+### Rolling queue (good-citizen throttle)
+
+- Per-`job_id` Redis state: `pending` (list of individual IDs), `in_flight` (counter), `completed`, `observations_sent`, `started_at`, `range`, per-individual `attempts`.
+- `backfill_max_concurrency` (K, default 8) is intentionally **below** `MOVEBANK_MAX_CONNECTIONS`, so a running backfill never consumes the entire connection budget — the scheduled pull and other integrations keep getting slots.
+- Hand-off is atomic ("mark self done, pop next, trigger it") so an individual is never double-dequeued under PubSub at-least-once redelivery.
+
+Two layers, two jobs: the **semaphore** guarantees we never exceed Movebank's hard limit; the **queue** keeps backfill from monopolizing it.
+
+## Watermarks & the backfill/pull boundary
+
+Backfill covers `[start, end)`; the steady-state pull covers `[end, ∞)`. They must partition the timeline with **no overlap and no gap**, because the transform's `loaded_at` field intentionally defeats Gundi's duplicate-drop — so any window fetched by both actions becomes duplicate observations in EarthRanger.
+
+- **`end`**, frozen per individual at job start:
+  - If the individual already has a steady-state pull cursor, `end` = that cursor's timestamp (backfill fills history *behind* the pull).
+  - If no cursor exists yet (backfill is the initial load), `end` = job start `T`, and the parent seeds the pull cursor to `T` so the pull only ever handles `[T, ∞)`. One-time initialization, not ongoing shared state.
+- **Backfill watermark** is separate Redis state (keyed by `job_id` + individual + sensor), so it never collides with the steady-state cursor. It advances forward from `start` toward `end`; the individual is done when it reaches `end`.
+- **Full-cursor hand-off.** When backfill finalizes an individual, it writes the steady-state pull cursor with **both** `latest_timestamp` **and** `highest_event_id` per sensor — not just the timestamp. This lets the pull's existing `event_id` filter absorb any time-window re-read at the boundary without re-emitting events backfill already sent.
+
+### Accessory-measurements boundary window — CRITICAL
+
+**Why this matters:** accessory-measurements records can arrive at Movebank **several hours after their event timestamp**. The device buffers them and uploads them late; Movebank stores them under their original (old) timestamp but they only become queryable hours later. The `movebank-client`'s built-in 60-minute accessory look-back was sized for *mild* reordering and is **not** enough for multi-hour settling.
+
+**The failure it prevents:** consider an accessory record timestamped `T` that arrives at Movebank 4 hours after `T`.
+- A timestamp-only watermark that has already advanced past `T` will never re-query `T` → the record is **missed** (a silent data gap, not a duplicate).
+- At the backfill/pull boundary the risk is sharpest: backfill sweeps `[start, end)` and finalizes; if the late record lands after backfill passed its timestamp but the pull only re-reads the last 60 minutes, neither action fetches it.
+
+**The change:** introduce a configurable **accessory settling margin**, `ACCESSORY_SETTLING_HOURS` (default **12**), applied to the **accessory-measurements sensor only**, in **both** places:
+
+1. **Steady-state pull** (change to existing shipped code): the accessory query re-reads back `ACCESSORY_SETTLING_HOURS` from the watermark instead of the client's 60 minutes, every run. The `event_id >= minimum_event_id` filter drops everything already emitted, so the wider re-read catches late arrivals **without producing duplicates**. GPS is unaffected (it does not arrive late) and keeps its exact-cursor behavior.
+2. **Backfill boundary hand-off**: because the pull re-reads `ACCESSORY_SETTLING_HOURS` of accessory history and the hand-off carries the `highest_event_id`, any accessory record that settles into the boundary region after backfill finished is picked up by the pull's next run and de-duplicated by event id.
+
+**Cost & bound:** the steady-state accessory query is wider every run (12 h vs 1 h of re-read), which means more rows scanned and filtered per run — acceptable because accessory volume is far lower than GPS and the event-id filter keeps the emitted set exact. `ACCESSORY_SETTLING_HOURS` is configurable so operators of studies with slower-settling devices can raise it; the guarantee is "no accessory record later than the margin is missed." Records that settle *beyond* the margin remain a documented residual risk, recoverable by re-running backfill for the affected range.
+
+GPS records are assumed to arrive promptly and are **not** subject to the settling margin.
+
+## Progress reporting
+
+Job metadata (Redis, per `job_id`) drives Activity Log records via the existing activity logger:
+
+- **Start**: "Backfill started for study `X`: `N` individuals, range `[start, end)`."
+- **Aggregate** (throttled with the existing `set_if_absent` TTL gate, ≈ every few minutes): "Backfill `Y`/`N` individuals complete, ~`M` observations." Emitted opportunistically as individuals finish, so a 500-individual job yields a readable trickle, not a flood.
+- **Complete**: "Backfill finished: `N` individuals, `M` observations, elapsed `T`." Emitted by whichever worker empties the queue with `in_flight == 0`.
+- **Per-individual**: no routine record; only a **warning** when an individual is abandoned after exhausting retries — so a stuck individual is visible without `2N` routine entries.
+
+(Progress lives in the Activity Log for now; there is no dedicated progress home in the Gundi UI yet.)
+
+## Error handling & edge cases
+
+- **Cascade guard**: a step that fetches zero events and cannot advance its watermark does **not** re-trigger — it finalizes the individual. Reaching `end` is the normal terminal condition. Prevents infinite cascades.
+- **Transient Movebank errors** (429/5xx/timeouts): the client already retries with bounded backoff; a step that still fails re-triggers itself up to a bounded `attempts` counter in job state, then logs the abandon warning and removes the individual from `in_flight` (dequeuing the next so the job keeps progressing).
+- **Semaphore leak protection**: slot TTL (above) plus `finally`-release.
+- **At-least-once redelivery**: watermark advancement is idempotent (a redelivered step re-fetches from the same watermark; the event-id filter dedups), and queue hand-off uses atomic Redis ops so an individual is not double-dequeued or double-triggered.
+- **One active job per integration**: re-triggering `backfill` while a job is in flight is guarded (new job refused, or explicitly supersedes) rather than clobbering live job state. A fresh `job_id` per accepted run.
+- **`MAX_ACTION_EXECUTION_TIME` retuning**: the step time budget is derived as ≈80% of the setting, so it tracks changes to the ack deadline.
+
+## Testing
+
+All in the Docker `mb-runner-test` image, `respx`-mocked Movebank, mocked Redis/Gundi, following existing `app/actions/tests` patterns.
+
+- **Semaphore**: acquire/release; ceiling enforcement; `DECR`-on-over-limit; TTL; backoff-re-trigger when full; pull and backfill share one counter.
+- **Rolling queue**: `K`-in-flight maintained; hand-off dequeues and triggers next; aggregate counters; completion detected when queue drains and `in_flight == 0`; no double-dequeue on redelivery.
+- **Watermark / boundary**: backfill covers `[start, end)`; `end` resolves from an existing cursor vs. seeds `T`; hand-off writes `(latest_timestamp, highest_event_id)`; `start="all"` resolves from `timestamp_start`.
+- **Accessory settling margin**: steady-state accessory query re-reads `ACCESSORY_SETTLING_HOURS`; a late-arriving accessory record within the margin is emitted exactly once (caught, not duplicated); GPS keeps exact-cursor behavior; a record beyond the margin is missed (documents the residual bound).
+- **Cascade**: time-budget stop re-triggers self with advanced watermark; reaching `end` finalizes; zero-yield terminates; abandon-after-retries logs warning and dequeues.
+- **Config / registration**: `backfill` registers executable; `backfill_individual` stays internal; discovery lists all actions.
+
+## Out of scope / deferred
+
+- GCS storage decoupling (revisit only if Gundi-side throughput is the bottleneck).
+- A dedicated progress surface in the Gundi UI (Activity Log records for now).
+- Cross-username coordination (semaphore is per-username; different usernames are independent budgets).
+- Sensor types beyond GPS and accessory-measurements.

--- a/docs/superpowers/specs/2026-07-21-movebank-backfill-design.md
+++ b/docs/superpowers/specs/2026-07-21-movebank-backfill-design.md
@@ -1,6 +1,6 @@
 # Movebank Backfill — Design
 
-**Status:** approved design, pre-implementation
+**Status:** implemented (PR #14)
 **Date:** 2026-07-21
 
 ## Goal


### PR DESCRIPTION
Operator-triggered backfill for a Movebank study's full history — built for high-frequency (vulture) individuals with hundreds of thousands of records, respecting Movebank's ~31-connection-per-username limit. Spec: docs/superpowers/specs/2026-07-21-movebank-backfill-design.md.

## What it adds
- **`backfill`** (executable): resolves the study's individuals (optional `individual_ids` filter), freezes each one's `[start, end)` range, seeds a Redis rolling work-queue, and dispatches up to `BACKFILL_MAX_CONCURRENCY` (8) sub-actions. `start` is a date or `"all"`.
- **`backfill_events_for_individual`** (internal, self-cascading): time-budgeted steps (0.8 × MAX_ACTION_EXECUTION_TIME) with a **persisted scan floor**, density-sized windows, per-sensor cursors; sends to Gundi inline; re-triggers itself until it reaches `end`, then hands the full `(timestamp, event_id)` cursor to the steady-state pull and dispatches the next queued individual (rolling K-in-flight).
- **Username-keyed Redis connection semaphore** (`movebank_slot`, default cap 25, shared across all integrations on one Redis) — the hard connection cap, adopted by the steady-state pull too.
- **Accessory-measurements settling margin** (`ACCESSORY_SETTLING_HOURS`, 12) on the steady-state pull, so multi-hour-late accessory records aren't missed; the event-id filter keeps the widened re-read duplicate-free.

## Boundary correctness
backfill `[start, end)` and pull `[end, ∞)` partition the timeline with no overlap (the transform's `loaded_at` defeats Gundi dedup, so overlap = duplicate observations). Fresh individuals: the pull cursor is seeded to `end` at job start and forward-merged at finalize. **Individuals that already have a pull cursor are skipped with a warning** — filling history *behind* an existing cursor is a deferred follow-up (see below).

## Review
Built via 8 TDD tasks with per-task review, then a whole-branch review that found and fixed: a chain-death path (fixed-window over-budget with no redelivery), month-scale duplication for existing-cursor individuals, a non-idempotent seed, and a primary-flow accessory duplication. Re-review verdict: **ready to merge**. Suite: **163 passed**.

## Deferred follow-ups (non-blocking)
- Fill history *behind* an existing pull cursor (currently skipped) — needs the pull to persist its oldest-covered floor.
- Finalize/seed cursor TOCTOU with a concurrent `*/10` pull (bounded ≤ one pull window; mitigate by pausing `run_on_schedule` during a big-study backfill).
- Job meta/configs/attempts Redis hashes not garbage-collected after completion.
- Abandoned-individual recovery has no self-serve path (documented for the runbook).
- `NoConnectionSlot` backoff has no jitter; `exists()`→seed not atomic (fast double-click); per-sub-action portal config lookup (template-level).

## Deployment watch (stage smoke test)
- `INTEGRATION_COMMANDS_TOPIC` push subscription to `POST /`, ack deadline ≥ 540s.
- After a backfill: "Backfill … finished" log + Redis `in_flight`=0/`pending`=0 (a stuck `in_flight` fingerprints a killed step).
- Don't double-click Run in the first seconds of a large-study backfill (until SET NX hardening lands).
- Spot-check EarthRanger for duplicates on a few fresh individuals; confirm the skipped-existing count matches expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)