### PR TITLE
Order AuthenticateConfig form fields (username, password)

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -3,11 +3,15 @@ from pydantic import Field, SecretStr
 from app.actions import AuthActionConfiguration, ExecutableActionMixin, PullActionConfiguration
 from app.actions.client import Individual
 from app.actions.core import InternalActionConfiguration
+from app.services.utils import GlobalUISchemaOptions
 
 
 class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
     username: str
     password: SecretStr = Field(..., format="password")
+    ui_global_options = GlobalUISchemaOptions(
+        order=["username", "password"],
+    )
 
 
 class PullObservationsConfig(PullActionConfiguration):


### PR DESCRIPTION
Adds `GlobalUISchemaOptions(order=["username", "password"])` to `AuthenticateConfig` so the Gundi Portal renders the auth form with **username above password**, instead of relying on default field ordering.

Emits `ui:order` in the action's `ui_schema` (verified); the JSON schema properties are unaffected (the `ui_global_options` field is stripped from `schema()` as usual). Full suite: 122 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)