### PR TITLE
Recent-first (reverse-chronological) backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,17 @@ This is Gundi's integration for pulling data from Movebank Studies.
   a separate cursor per sensor type (GPS, accessory-measurements), batches requests in
   adaptive time windows, transforms events into observations, and sends them to Gundi.
   State lives in Redis keyed by integration/action/individual.
-- **backfill** (executable) — operator-triggered historical load for a study.
-  Works on a fresh integration and on one that already has collection history:
-  each individual is back-filled up to its recorded coverage floor
-  (`coverage_start`), so backfill and the steady-state pull partition the
-  timeline with no gap or overlap. Each cascade step processes bounded windows
+- **backfill** (executable) — operator-triggered historical load for a study,
+  processed **newest-first**: recent history reaches EarthRanger before older
+  data. Works on a fresh integration and on one that already has collection
+  history: each individual is back-filled down from its recorded coverage
+  floor (`coverage_start`) toward `start`, so backfill and the steady-state
+  pull partition the timeline with no gap or overlap. Each cascade step
+  processes a bounded window descending toward `start`
   (`MAX_RECORDS_PER_BACKFILL_WINDOW`, adaptively shrunk down to
-  `MIN_BACKFILL_WINDOW_SECONDS` on dense data) so a step always finishes inside
-  the execution budget and cleanly cascades. Set `restart: true` to clear a
-  stuck/previous job for the same parameters and start over. Config:
+  `MIN_BACKFILL_WINDOW_SECONDS` on dense data); progress is persisted every
+  window, so an interrupted job resumes with no rework. Set `restart: true` to
+  clear a stuck/previous job for the same parameters and start over. Config:
   `study_id`, optional `individual_ids`, `start` (a date or `"all"`), optional
   `backfill_max_concurrency`, `restart`.
 - **backfill_events_for_individual** (internal) — self-cascading worker for one

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -755,6 +755,14 @@ async def action_backfill_events_for_individual(integration, action_config: Back
                         ):
                             events.append(event)
 
+                if window_interrupted:
+                    # Deadline hit mid-window (between sensors): discard the
+                    # partial fetch — we only ever send a WHOLE window
+                    # (atomicity). Cursor/scan_from stay put; the whole window is
+                    # re-fetched next step. Nothing was sent, so there is no
+                    # dedup floor to maintain and no duplicate on retry.
+                    break
+
                 # Timestamp-range ownership: keep only events whose timestamp is
                 # in this window's half-open [lower, upper). Discards the client's
                 # accessory 60-min pre-roll and the whole-second timestamp_end
@@ -771,8 +779,7 @@ async def action_backfill_events_for_individual(integration, action_config: Back
                         kept.append(e)
 
                 # Overflow guard on KEPT (send) volume — see step-budget design.
-                if (not window_interrupted
-                        and len(kept) > settings.MAX_RECORDS_PER_BACKFILL_WINDOW
+                if (len(kept) > settings.MAX_RECORDS_PER_BACKFILL_WINDOW
                         and window > min_window):
                     shrunk = (window.total_seconds()
                               * settings.MAX_RECORDS_PER_BACKFILL_WINDOW / len(kept)
@@ -789,8 +796,7 @@ async def action_backfill_events_for_individual(integration, action_config: Back
                         f"shrunk to {window.total_seconds():.0f}s, retrying"
                     )
                     continue
-                if (not window_interrupted
-                        and len(kept) > settings.MAX_RECORDS_PER_BACKFILL_WINDOW):
+                if len(kept) > settings.MAX_RECORDS_PER_BACKFILL_WINDOW:
                     logger.warning(
                         f"Backfill {log_reference}: window at floor "
                         f"({settings.MIN_BACKFILL_WINDOW_SECONDS}s) still over cap "
@@ -808,8 +814,7 @@ async def action_backfill_events_for_individual(integration, action_config: Back
                 # and harmless (may reflect the oldest window's values).
                 _advance_watermarks(state, kept, sensor_type_ids, sensor_type_timestamps, minimum_event_ids)
                 observations_sent += len(observations)
-                if not window_interrupted:
-                    cursor = window_lower       # descend
+                cursor = window_lower       # descend
 
                 blob = json.loads(state.json())
                 blob["scan_from"] = cursor.isoformat()
@@ -821,7 +826,7 @@ async def action_backfill_events_for_individual(integration, action_config: Back
                 # expected even with density-based sizing. Stop taking more
                 # windows once this step's total crosses the cap, rather than
                 # risking the invocation running past its execution budget.
-                if window_interrupted or observations_sent >= MAX_RECORDS_PER_BACKFILL_STEP:
+                if observations_sent >= MAX_RECORDS_PER_BACKFILL_STEP:
                     break
     except asyncio.CancelledError:
         # Hard execution-timeout: asyncio.wait_for in the action runner cancels

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -612,56 +612,62 @@ async def _dispatch_backfill_individual(integration_id, job, individual_id):
     logger.warning(f"Backfill {job.job_id}: exhausted pending queue looking for a valid config to dispatch")
 
 
-async def _record_abandoned_coverage(integration_id, ind, action_config, floor):
-    """On abandon, lower the pull cursor's coverage_start to the reached floor so
-    the recent portion a reverse backfill DID cover is recorded (a later fresh
-    backfill sees a smaller remaining range). Single best-effort write on a rare
-    path; preserves the pull's sensor cursors as read.
+async def _merge_backfill_into_pull_cursor(
+        integration_id, ind, action_config, state, *, coverage_start, lower_only=False, create_if_missing=True
+):
+    """Merge the backfill watermark FORWARD into the steady-state pull cursor and
+    set its coverage floor.
 
-    Only writes when a pull cursor already exists. In production the seed
-    (_seed_pull_cursor_at_end) always runs before this path can be reached, so
-    a cursor is always present — but without this guard, a missing cursor
-    would fall back to constructing a fresh, sensor-less IndividualState here
-    and writing it, clobbering nothing today but creating a footgun for a
-    future caller that skips the seed."""
-    raw = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
-    if not raw:
+    Per sensor, take max(existing, backfill) on both the timestamp and the
+    highest event id. This carries backfill's event-ids forward — so the pull's
+    accessory settling re-read dedups against them — without ever moving a
+    running pull's cursor backward (action_backfill may already have claimed a
+    forward cursor at job start via _seed_pull_cursor_at_end, and a live pull may
+    have advanced it further while backfill ran). In reverse backfill the sent
+    windows are processed newest-first, so `state` holds the most-recent
+    event-ids (see _advance_watermarks' cumulative-max) — exactly what the
+    settling re-read needs to filter the seam.
+
+    coverage_start handling:
+      - lower_only=False (success finalize): set coverage_start = coverage_start
+        (the backfill's `start` — full coverage claimed down to there).
+      - lower_only=True (abandon): only lower coverage_start toward the reached
+        floor; never raise it, so a prior deeper backfill's floor is preserved.
+
+    create_if_missing=False (abandon) skips writing entirely when no pull cursor
+    exists yet — in production the seed always ran first, and we don't want a
+    caller that skipped the seed to materialise a cursor here.
+    """
+    existing_raw = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
+    if not existing_raw and not create_if_missing:
         return
-    existing = IndividualState.parse_obj(raw)
-    if existing.coverage_start is None or floor < existing.coverage_start:
-        existing.coverage_start = floor
+    existing_state = IndividualState.parse_obj(existing_raw) if existing_raw else IndividualState(
+        individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
+    )
+    for stid_str, backfill_ss in state.sensor_states.items():
+        stid = int(stid_str)
+        existing_ss = existing_state.get_sensor_state(stid)
+        candidate_stamps = [t for t in (existing_ss.latest_timestamp, backfill_ss.latest_timestamp) if t]
+        if candidate_stamps:
+            new_ts = max(candidate_stamps)
+            new_event_id = max(existing_ss.highest_event_id or 0, backfill_ss.highest_event_id or 0)
+            existing_state.update_sensor_state(stid, new_ts, new_event_id)
+    if lower_only:
+        if existing_state.coverage_start is None or coverage_start < existing_state.coverage_start:
+            existing_state.coverage_start = coverage_start
+    else:
+        existing_state.coverage_start = coverage_start
     await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
-                                  json.loads(existing.json()), source_id=ind.id)
+                                  json.loads(existing_state.json()), source_id=ind.id)
 
 
 async def _finalize_backfill_individual(integration_id, job, ind, action_config, *, observations, state=None):
-    # Merge the backfill watermark FORWARD into the steady-state pull cursor:
-    # per sensor, take max(existing, backfill) on both the timestamp and the
-    # highest event id. This carries backfill's event-ids forward (so the
-    # pull's accessory settling re-read dedups against them) without ever
-    # moving a running pull's cursor backward — action_backfill may already
-    # have claimed a forward cursor for this individual at job start (see
-    # _seed_pull_cursor_at_end), and a live pull may have advanced it further
-    # still while backfill was running.
     if state is not None:
-        existing_raw = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
-        existing_state = IndividualState.parse_obj(existing_raw) if existing_raw else IndividualState(
-            individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
+        # Success: carry backfill's per-sensor maxima forward and claim coverage
+        # down to action_config.start.
+        await _merge_backfill_into_pull_cursor(
+            integration_id, ind, action_config, state, coverage_start=action_config.start
         )
-        for stid_str, backfill_ss in state.sensor_states.items():
-            stid = int(stid_str)
-            existing_ss = existing_state.get_sensor_state(stid)
-            candidate_stamps = [t for t in (existing_ss.latest_timestamp, backfill_ss.latest_timestamp) if t]
-            if candidate_stamps:
-                new_ts = max(candidate_stamps)
-                new_event_id = max(existing_ss.highest_event_id or 0, backfill_ss.highest_event_id or 0)
-                existing_state.update_sensor_state(stid, new_ts, new_event_id)
-        # Backfill has now covered down to action_config.start, so the combined
-        # coverage floor moves there — a later backfill with the same/later start
-        # will see an empty range for this individual.
-        existing_state.coverage_start = action_config.start
-        await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
-                                      json.loads(existing_state.json()), source_id=ind.id)
     await job.record_completion(observations)
     await job.decr_in_flight()
 
@@ -892,7 +898,15 @@ async def action_backfill_events_for_individual(integration, action_config: Back
             logger.info(f"Backfill {action_config.job_id}/{ind.id}: attempt {attempts} failed ({exc}); retrying")
             return {"status": "retry", "attempts": attempts}
         logger.warning(f"Backfill {action_config.job_id}/{ind.id}: abandoned after {attempts} attempts: {exc}")
-        await _record_abandoned_coverage(integration_id, ind, action_config, floor=cursor)
+        # Carry whatever backfill DID send (recent windows, processed first)
+        # forward into the pull cursor so its accessory settling re-read dedups
+        # the seam, and lower coverage_start to the reached floor — WITHOUT
+        # claiming full completion. Then finalize with state=None so it doesn't
+        # merge again or move coverage_start to `start`.
+        await _merge_backfill_into_pull_cursor(
+            integration_id, ind, action_config, state,
+            coverage_start=cursor, lower_only=True, create_if_missing=False,
+        )
         result = await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
         return {"status": "abandoned", **{k: v for k, v in result.items() if k != "status"}}
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -131,8 +131,19 @@ def _advance_watermarks(state, events, sensor_type_ids, sensor_type_timestamps, 
             except (TypeError, ValueError):
                 pass
         if stamps or ids:
-            new_latest = max(stamps) if stamps else sensor_type_timestamps[stid]
-            new_max = max(ids) if ids else minimum_event_ids[stid] - 1
+            existing = state.get_sensor_state(stid)
+            window_latest = max(stamps) if stamps else sensor_type_timestamps[stid]
+            window_max_id = max(ids) if ids else minimum_event_ids[stid] - 1
+            # Never move a sensor cursor BACKWARD: max against what's already
+            # stored. The steady-state pull is monotonic-forward, so this is a
+            # no-op there; reverse backfill processes RECENT windows first, so
+            # this preserves the most-recent window's timestamp/event-id for the
+            # finalize forward-merge. Carrying the oldest window's lower id would
+            # let the pull's accessory settling re-read re-emit seam events as
+            # duplicates.
+            candidate_stamps = [t for t in (existing.latest_timestamp, window_latest) if t]
+            new_latest = max(candidate_stamps) if candidate_stamps else window_latest
+            new_max = max(existing.highest_event_id or 0, window_max_id)
             state.update_sensor_state(stid, new_latest, new_max)
             sensor_type_timestamps[stid] = new_latest
             minimum_event_ids[stid] = new_max + 1
@@ -605,11 +616,18 @@ async def _record_abandoned_coverage(integration_id, ind, action_config, floor):
     """On abandon, lower the pull cursor's coverage_start to the reached floor so
     the recent portion a reverse backfill DID cover is recorded (a later fresh
     backfill sees a smaller remaining range). Single best-effort write on a rare
-    path; preserves the pull's sensor cursors as read."""
+    path; preserves the pull's sensor cursors as read.
+
+    Only writes when a pull cursor already exists. In production the seed
+    (_seed_pull_cursor_at_end) always runs before this path can be reached, so
+    a cursor is always present — but without this guard, a missing cursor
+    would fall back to constructing a fresh, sensor-less IndividualState here
+    and writing it, clobbering nothing today but creating a footgun for a
+    future caller that skips the seed."""
     raw = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
-    existing = IndividualState.parse_obj(raw) if raw else IndividualState(
-        individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
-    )
+    if not raw:
+        return
+    existing = IndividualState.parse_obj(raw)
     if existing.coverage_start is None or floor < existing.coverage_start:
         existing.coverage_start = floor
     await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
@@ -823,10 +841,15 @@ async def action_backfill_events_for_individual(integration, action_config: Back
                 for batch in chunks(observations, OBSERVATIONS_BATCH_SIZE):
                     await send_observations_to_gundi(observations=batch, integration_id=integration_id)
 
-                # Vestigial in reverse: advances per-sensor state from the kept
-                # events. Used only by the finalize forward-merge, which is inert
-                # here (backfill's max is below coverage_start). Kept for parity
-                # and harmless (may reflect the oldest window's values).
+                # Advances per-sensor state from the kept events, cumulative-max
+                # (see _advance_watermarks). In this REVERSE descent, windows are
+                # visited recent-first, so `state` ends up holding the MOST
+                # RECENT window's per-sensor timestamp/event-id — exactly what
+                # _finalize_backfill_individual needs to merge forward into the
+                # pull cursor. (An overwrite here would instead finalize with the
+                # OLDEST window's values, handing the pull cursor a too-low
+                # accessory event-id floor and letting its settling re-read
+                # re-emit already-sent seam events as duplicates.)
                 _advance_watermarks(state, kept, sensor_type_ids, sensor_type_timestamps, minimum_event_ids)
                 observations_sent += len(observations)
                 cursor = window_lower       # descend

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -601,6 +601,21 @@ async def _dispatch_backfill_individual(integration_id, job, individual_id):
     logger.warning(f"Backfill {job.job_id}: exhausted pending queue looking for a valid config to dispatch")
 
 
+async def _record_abandoned_coverage(integration_id, ind, action_config, floor):
+    """On abandon, lower the pull cursor's coverage_start to the reached floor so
+    the recent portion a reverse backfill DID cover is recorded (a later fresh
+    backfill sees a smaller remaining range). Single best-effort write on a rare
+    path; preserves the pull's sensor cursors as read."""
+    raw = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
+    existing = IndividualState.parse_obj(raw) if raw else IndividualState(
+        individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
+    )
+    if existing.coverage_start is None or floor < existing.coverage_start:
+        existing.coverage_start = floor
+    await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
+                                  json.loads(existing.json()), source_id=ind.id)
+
+
 async def _finalize_backfill_individual(integration_id, job, ind, action_config, *, observations, state=None):
     # Merge the backfill watermark FORWARD into the steady-state pull cursor:
     # per sensor, take max(existing, backfill) on both the timestamp and the
@@ -854,6 +869,7 @@ async def action_backfill_events_for_individual(integration, action_config: Back
             logger.info(f"Backfill {action_config.job_id}/{ind.id}: attempt {attempts} failed ({exc}); retrying")
             return {"status": "retry", "attempts": attempts}
         logger.warning(f"Backfill {action_config.job_id}/{ind.id}: abandoned after {attempts} attempts: {exc}")
+        await _record_abandoned_coverage(integration_id, ind, action_config, floor=cursor)
         result = await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
         return {"status": "abandoned", **{k: v for k, v in result.items() if k != "status"}}
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -686,12 +686,14 @@ async def action_backfill_events_for_individual(integration, action_config: Back
         sensor_type_timestamps[stid] = ss.latest_timestamp or action_config.start
         minimum_event_ids[stid] = (ss.highest_event_id or 0) + 1
 
-    # The scan position is a DURABLE floor, persisted every window regardless
+    # The scan position is a DURABLE cursor, persisted every window regardless
     # of whether events came back. Windows are anchored to it (below), not to
     # the per-sensor event cursor above — otherwise a sensor that returns
     # nothing for the whole range would never move its own cursor, and a
-    # re-trigger after a budget-exhausted step would recompute `current` from
+    # re-trigger after a budget-exhausted step would recompute the cursor from
     # that unmoved cursor and rescan the same empty span forever (livelock).
+    # It descends from `end` toward `start`; at any point we have covered
+    # `[scan_from, end)` and still owe `[start, scan_from)`.
     persisted_scan_from = None
     if saved and saved.get("scan_from"):
         try:
@@ -711,7 +713,11 @@ async def action_backfill_events_for_individual(integration, action_config: Back
     min_window = timedelta(seconds=settings.MIN_BACKFILL_WINDOW_SECONDS)
     window = max(window, min_window)
     observations_sent = 0
-    current = persisted_scan_from if persisted_scan_from is not None else min(sensor_type_timestamps.values())
+    # Reverse (recent-first): `cursor` is the LOWER edge of coverage so far — we
+    # have covered [cursor, end) and still owe [start, cursor). It begins at
+    # `end` (= coverage_start) and descends toward `start`; a persisted position
+    # resumes the descent. (The backfill watermark's scan_from stores it.)
+    cursor = persisted_scan_from if persisted_scan_from is not None else action_config.end
 
     mb_client = client.MovebankClient(
         base_url=integration.base_url, username=auth_config.username,
@@ -726,10 +732,9 @@ async def action_backfill_events_for_individual(integration, action_config: Back
     # second time, double-counting record_completion/decr_in_flight.
     try:
         async with mb_client as mb:
-            while current < action_config.end and time.monotonic() < deadline:
-                end_at = min(action_config.end, current + window)
-                # All sensors sweep the same [current, end_at) window together —
-                # anchored to the scan floor, not each sensor's own cursor.
+            while cursor > action_config.start and time.monotonic() < deadline:
+                window_lower = max(action_config.start, cursor - window)
+                window_upper = cursor
                 events = []
                 window_interrupted = False
                 for stid in sensor_type_ids:
@@ -742,66 +747,72 @@ async def action_backfill_events_for_individual(integration, action_config: Back
                     if time.monotonic() >= deadline:
                         window_interrupted = True
                         break
-                    query_start = _query_start_for_sensor(stid, current, minimum_event_ids[stid])
                     async with movebank_slot(auth_config.username):
                         async for event in mb.get_individual_events_by_time(
                             study_id=action_config.study_id, individual_id=ind.id,
-                            timestamp_start=query_start, timestamp_end=end_at,
-                            sensor_type_ids=[stid], minimum_event_id=minimum_event_ids[stid],
+                            timestamp_start=window_lower, timestamp_end=window_upper,
+                            sensor_type_ids=[stid], minimum_event_id=0,
                         ):
                             events.append(event)
 
-                # Overflow guard: only SEND a window we can finish within the
-                # budget. A FULLY-fetched window (not deadline-interrupted) with
-                # more than the per-window cap is discarded — nothing sent,
-                # watermarks and scan floor untouched — and the window is shrunk
-                # proportionally, persisted, and retried at the same `current`.
-                # Never shrink below the floor; at the floor, fall through and
-                # send even if over cap (a burst denser than the floor holds).
+                # Timestamp-range ownership: keep only events whose timestamp is
+                # in this window's half-open [lower, upper). Discards the client's
+                # accessory 60-min pre-roll and the whole-second timestamp_end
+                # truncation, so each event belongs to exactly one window and no
+                # cross-window event-id dedup is needed. Unparseable timestamps
+                # are dropped (build_observation would drop them anyway).
+                kept = []
+                for e in events:
+                    try:
+                        ts = _ensure_utc(parse_date(e.get("timestamp")))
+                    except Exception:
+                        continue
+                    if window_lower <= ts < window_upper:
+                        kept.append(e)
+
+                # Overflow guard on KEPT (send) volume — see step-budget design.
                 if (not window_interrupted
-                        and len(events) > settings.MAX_RECORDS_PER_BACKFILL_WINDOW
+                        and len(kept) > settings.MAX_RECORDS_PER_BACKFILL_WINDOW
                         and window > min_window):
                     shrunk = (window.total_seconds()
-                              * settings.MAX_RECORDS_PER_BACKFILL_WINDOW / len(events)
+                              * settings.MAX_RECORDS_PER_BACKFILL_WINDOW / len(kept)
                               * settings.BACKFILL_WINDOW_SHRINK_SAFETY)
                     window = max(min_window, timedelta(seconds=shrunk))
                     blob = json.loads(state.json())
-                    blob["scan_from"] = current.isoformat()           # unchanged
+                    blob["scan_from"] = cursor.isoformat()           # unchanged (cursor not advanced)
                     blob["window_seconds"] = window.total_seconds()
                     await state_manager.set_state(integration_id, BACKFILL_WATERMARK_ACTION_ID,
                                                   blob, source_id=watermark_source)
                     logger.info(
                         f"Backfill {log_reference}: window over cap "
-                        f"({len(events)} > {settings.MAX_RECORDS_PER_BACKFILL_WINDOW}); "
+                        f"({len(kept)} > {settings.MAX_RECORDS_PER_BACKFILL_WINDOW}); "
                         f"shrunk to {window.total_seconds():.0f}s, retrying"
                     )
                     continue
                 if (not window_interrupted
-                        and len(events) > settings.MAX_RECORDS_PER_BACKFILL_WINDOW):
+                        and len(kept) > settings.MAX_RECORDS_PER_BACKFILL_WINDOW):
                     logger.warning(
                         f"Backfill {log_reference}: window at floor "
                         f"({settings.MIN_BACKFILL_WINDOW_SECONDS}s) still over cap "
-                        f"({len(events)} events); sending anyway"
+                        f"({len(kept)} events); sending anyway"
                     )
 
                 device_name = _display_name(ind)
-                observations = [o for e in events if (o := build_observation(event=e, device_name=device_name)) is not None]
+                observations = [o for e in kept if (o := build_observation(event=e, device_name=device_name)) is not None]
                 for batch in chunks(observations, OBSERVATIONS_BATCH_SIZE):
                     await send_observations_to_gundi(observations=batch, integration_id=integration_id)
 
-                _advance_watermarks(state, events, sensor_type_ids, sensor_type_timestamps, minimum_event_ids)
+                # Vestigial in reverse: advances per-sensor state from the kept
+                # events. Used only by the finalize forward-merge, which is inert
+                # here (backfill's max is below coverage_start). Kept for parity
+                # and harmless (may reflect the oldest window's values).
+                _advance_watermarks(state, kept, sensor_type_ids, sensor_type_timestamps, minimum_event_ids)
                 observations_sent += len(observations)
                 if not window_interrupted:
-                    # Only advance past this window if EVERY sensor was fetched
-                    # for it; an interrupted window is retried in full next
-                    # step (safe: per-sensor minimum_event_id already advanced
-                    # for whichever sensors DID get fetched, so no duplicates).
-                    current = current + window
+                    cursor = window_lower       # descend
 
-                # Persist the scan floor together with the sensor states in a
-                # single call, every window, regardless of whether events came back.
                 blob = json.loads(state.json())
-                blob["scan_from"] = current.isoformat()
+                blob["scan_from"] = cursor.isoformat()
                 blob["window_seconds"] = window.total_seconds()
                 await state_manager.set_state(integration_id, BACKFILL_WATERMARK_ACTION_ID,
                                               blob, source_id=watermark_source)
@@ -821,7 +832,7 @@ async def action_backfill_events_for_individual(integration, action_config: Back
         # in_flight unwind): awaits during cancellation are themselves cancelled
         # and unreliable. Recover a job wedged by a timeout with restart=true.
         logger.warning(
-            f"Backfill {log_reference}: step hard-cancelled at scan_from={current.isoformat()}; "
+            f"Backfill {log_reference}: step hard-cancelled at scan_from={cursor.isoformat()}; "
             "resume on next trigger or re-run with restart=true"
         )
         raise
@@ -847,12 +858,13 @@ async def action_backfill_events_for_individual(integration, action_config: Back
     # count against BACKFILL_MAX_ATTEMPTS.
     await job.reset_attempts(ind.id)
 
-    if current < action_config.end:
-        # Budget exhausted mid-range: continue THIS individual on the next step.
+    if cursor > action_config.start:
+        # Budget exhausted mid-range: continue THIS individual on the next step
+        # (descending from the persisted cursor).
         await trigger_action(
             integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=action_config,
         )
-        logger.info(f"Backfill {log_reference} continued at {current.isoformat()} ({observations_sent} obs this step)")
+        logger.info(f"Backfill {log_reference} continued at {cursor.isoformat()} ({observations_sent} obs this step)")
         return {"status": "continued", "observations_sent": observations_sent}
 
     return await _finalize_backfill_individual(

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -641,9 +641,15 @@ async def _merge_backfill_into_pull_cursor(
     existing_raw = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
     if not existing_raw and not create_if_missing:
         return
+    existed = bool(existing_raw)
     existing_state = IndividualState.parse_obj(existing_raw) if existing_raw else IndividualState(
         individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
     )
+    # Track whether anything actually changes: this key is also written by the
+    # scheduled pull, so every needless get/merge/set is another chance to
+    # clobber a concurrent pull-cursor advance (TOCTOU). Only write when a field
+    # really moves — or when we just created the cursor.
+    changed = not existed
     for stid_str, backfill_ss in state.sensor_states.items():
         stid = int(stid_str)
         existing_ss = existing_state.get_sensor_state(stid)
@@ -651,14 +657,20 @@ async def _merge_backfill_into_pull_cursor(
         if candidate_stamps:
             new_ts = max(candidate_stamps)
             new_event_id = max(existing_ss.highest_event_id or 0, backfill_ss.highest_event_id or 0)
-            existing_state.update_sensor_state(stid, new_ts, new_event_id)
+            if new_ts != existing_ss.latest_timestamp or new_event_id != (existing_ss.highest_event_id or 0):
+                existing_state.update_sensor_state(stid, new_ts, new_event_id)
+                changed = True
     if lower_only:
-        if existing_state.coverage_start is None or coverage_start < existing_state.coverage_start:
+        if (existing_state.coverage_start is None or coverage_start < existing_state.coverage_start) \
+                and existing_state.coverage_start != coverage_start:
             existing_state.coverage_start = coverage_start
-    else:
+            changed = True
+    elif existing_state.coverage_start != coverage_start:
         existing_state.coverage_start = coverage_start
-    await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
-                                  json.loads(existing_state.json()), source_id=ind.id)
+        changed = True
+    if changed:
+        await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
+                                      json.loads(existing_state.json()), source_id=ind.id)
 
 
 async def _finalize_backfill_individual(integration_id, job, ind, action_config, *, observations, state=None):

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -228,6 +228,45 @@ def make_windowed_events_generator(per_window, sensor_type_id="653"):
     return _gen, calls
 
 
+def make_reverse_windowed_events_generator(events_per_window, sensor_type_id, overall_start):
+    """Stand-in for get_individual_events_by_time whose events' event_id is
+    derived from each event's own TIMESTAMP (seconds since `overall_start`), so
+    a LATER timestamp always gets a HIGHER event_id — matching Movebank reality
+    (ids increase with time).
+
+    This is deliberately different from make_windowed_events_generator above,
+    which assigns higher ids to LATER CALLS. In a reverse (recent-first)
+    descent, later calls are OLDER windows — the opposite of reality, and not
+    useful for proving which window's id should win the finalize merge. Here,
+    event_id tracks wall-clock time directly, so whichever window is actually
+    more recent has the higher ids, regardless of call order.
+    """
+    calls = {"count": 0, "windows": [], "window_events": []}
+
+    async def _gen(**kwargs):
+        start = kwargs["timestamp_start"]
+        end = kwargs["timestamp_end"]
+        calls["windows"].append((start, end))
+        calls["count"] += 1
+        span = (end - start).total_seconds()
+        window_events = []
+        for i in range(events_per_window):
+            # Evenly place events strictly inside [start, end).
+            offset = span * (i + 1) / (events_per_window + 1)
+            ts = start + timedelta(seconds=offset)
+            event_id = int((ts - overall_start).total_seconds())
+            event = {
+                "event_id": str(event_id),
+                "timestamp": ts.strftime("%Y-%m-%d %H:%M:%S.000"),
+                "individual_id": "111",
+                "sensor_type_id": str(sensor_type_id),
+            }
+            window_events.append(event)
+            yield event
+        calls["window_events"].append(window_events)
+    return _gen, calls
+
+
 @pytest.mark.asyncio
 async def test_pull_events_respects_max_records_cap(
         mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
@@ -724,11 +763,23 @@ async def test_backfill_individual_abandoned_after_max_attempts(
                  AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0, "in_flight": 0, "range": "r"}))
     warn = mocker.patch("app.actions.handlers.logger.warning")
 
+    backfill_end = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    # Mirror production: action_backfill's _seed_pull_cursor_at_end always runs
+    # before a sub-action can be dispatched, so a pull cursor already exists by
+    # the time this abandon path is reached. _record_abandoned_coverage now
+    # only writes onto an existing cursor (MINOR fix); pre-seed one here so
+    # that lower-on-existing path is actually exercised instead of the
+    # create-fresh path it used to fall back to.
+    seeded = IndividualState(individual_id="111", study_id="12345", local_identifier="tag-1")
+    seeded.coverage_start = backfill_end
+    seeded.update_sensor_state(653, backfill_end, 0)
+    mock_state_store[(str(integration.id), "pull_events_for_individual", "111")] = seeded.dict()
+
     result = await action_backfill_events_for_individual(
         integration=integration,
         action_config=BackfillEventsForIndividualConfig(
             study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1",
-            start=datetime(2024, 1, 1, tzinfo=timezone.utc), end=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            start=datetime(2024, 1, 1, tzinfo=timezone.utc), end=backfill_end,
         ),
     )
     assert result["status"] == "abandoned"
@@ -1502,6 +1553,73 @@ async def test_finalize_sets_coverage_start_to_backfill_start(
 
     saved = mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
     assert IndividualState.parse_obj(saved).coverage_start == start
+
+
+@pytest.mark.asyncio
+async def test_backfill_reverse_finalize_carries_recent_windows_event_id_forward(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    """CRITICAL regression test: reverse backfill descends recent-window-first,
+    so across a multi-window run, _finalize_backfill_individual's forward-merge
+    into the pull cursor must carry the RECENT window's (highest) per-sensor
+    event_id — not the OLDEST window's (lowest), which is the one processed
+    LAST and would win under a naive overwrite.
+
+    Uses a real-timestamp-derived event_id (via
+    make_reverse_windowed_events_generator) rather than
+    make_windowed_events_generator, whose ids increase with CALL order — the
+    opposite of reverse-descent reality, where the first call is the most
+    recent window.
+
+    Before the _advance_watermarks cumulative-max fix, each window's call to
+    state.update_sensor_state OVERWROTE the running per-sensor state, so by
+    the time the descent reached the oldest (last-processed) window, `state`
+    held THAT window's low event_id — which finalize then merged into the pull
+    cursor, handing its accessory-settling re-read a too-low dedup floor and
+    letting it re-emit already-sent seam events as duplicates. This test fails
+    before the fix and passes after.
+    """
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    ACCESSORY_SENSOR_ID = 7842954
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 11, tzinfo=timezone.utc)  # 10 days -> exactly two 5-day (default) windows
+    gen, calls = make_reverse_windowed_events_generator(3, ACCESSORY_SENSOR_ID, overall_start=start)
+    mock_movebank_client.get_individual_events_by_time = gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 6,
+                                          "in_flight": 0, "pending_remaining": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
+
+    individual = {**INDIVIDUAL_ROW, "sensor_type_ids": "accessory-measurements"}
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=individual, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "completed"
+    assert calls["count"] == 2  # exactly two windows: recent [end-5d, end), then older [start, end-5d)
+
+    recent_window_start, _ = calls["windows"][0]
+    older_window_start, _ = calls["windows"][1]
+    assert recent_window_start > older_window_start  # sanity: window 0 really is the more recent one
+
+    recent_ids = [int(e["event_id"]) for e in calls["window_events"][0]]
+    older_ids = [int(e["event_id"]) for e in calls["window_events"][1]]
+    assert max(recent_ids) > max(older_ids)  # sanity: the generator really gave recent events higher ids
+
+    merged = IndividualState.parse_obj(
+        mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
+    )
+    merged_ss = merged.get_sensor_state(ACCESSORY_SENSOR_ID)
+    assert merged_ss.highest_event_id == max(recent_ids)
+    assert merged_ss.highest_event_id != max(older_ids)
 
 
 @pytest.mark.asyncio

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -766,10 +766,10 @@ async def test_backfill_individual_abandoned_after_max_attempts(
     backfill_end = datetime(2026, 1, 1, tzinfo=timezone.utc)
     # Mirror production: action_backfill's _seed_pull_cursor_at_end always runs
     # before a sub-action can be dispatched, so a pull cursor already exists by
-    # the time this abandon path is reached. _record_abandoned_coverage now
-    # only writes onto an existing cursor (MINOR fix); pre-seed one here so
-    # that lower-on-existing path is actually exercised instead of the
-    # create-fresh path it used to fall back to.
+    # the time this abandon path is reached. The abandon merge
+    # (_merge_backfill_into_pull_cursor with create_if_missing=False) only writes
+    # onto an existing cursor; pre-seed one here so that path is exercised
+    # instead of the create-fresh path it must NOT take.
     seeded = IndividualState(individual_id="111", study_id="12345", local_identifier="tag-1")
     seeded.coverage_start = backfill_end
     seeded.update_sensor_state(653, backfill_end, 0)
@@ -2082,5 +2082,9 @@ async def test_backfill_abandon_lowers_coverage_start_to_reached_floor(
 
     assert result["status"] == "abandoned"
     saved = mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
+    merged = IndividualState.parse_obj(saved)
     # Lowered from end (2024-06-01) to the reached floor (2024-05-02).
-    assert IndividualState.parse_obj(saved).coverage_start == datetime(2024, 5, 2, tzinfo=timezone.utc)
+    assert merged.coverage_start == datetime(2024, 5, 2, tzinfo=timezone.utc)
+    # The recent window's event-id was merged FORWARD into the pull cursor so the
+    # pull's accessory settling re-read dedups the seam (not just coverage_start).
+    assert merged.sensor_states["653"].highest_event_id == 1

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -736,8 +736,11 @@ async def test_backfill_individual_abandoned_after_max_attempts(
     # Finalize ran exactly once on the abandon path — no double-counting.
     assert mock_record_completion.await_count == 1
     assert mock_decr_in_flight.await_count == 1
-    # Abandoned with observations=0 and no state: no pull cursor handed off.
-    assert (str(integration.id), "pull_events_for_individual", "111") not in mock_state_store
+    # Abandoned with zero progress (cursor never descended past `end`): the
+    # reached-floor record still writes, but at the original boundary — a
+    # no-op floor, not a data loss.
+    saved = mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
+    assert IndividualState.parse_obj(saved).coverage_start == datetime(2026, 1, 1, tzinfo=timezone.utc)
 
 
 @pytest.mark.asyncio
@@ -1905,3 +1908,61 @@ async def test_backfill_resumes_from_persisted_descending_cursor(
 
     assert calls["windows"][0][1] == datetime(2024, 6, 1, tzinfo=timezone.utc)          # resumed at scan_from
     assert calls["windows"][0][0] == datetime(2024, 5, 31, tzinfo=timezone.utc)         # one 1-day window down
+
+
+@pytest.mark.asyncio
+async def test_backfill_abandon_lowers_coverage_start_to_reached_floor(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # One window completes (cursor descends), then fetches fail and the
+    # individual is abandoned; coverage_start must be LOWERED to the reached
+    # floor (the descended cursor), not left at its original value.
+    from app.actions.handlers import BACKFILL_MAX_ATTEMPTS
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    # A 30-day window means the first window is [end - 30d, end) = [2024-05-02, 2024-06-01).
+    st = IndividualState(individual_id="111", study_id="12345")
+    mock_state_store[(str(integration.id), "backfill_watermark", "job-1.111")] = {
+        **st.dict(), "window_seconds": 2592000.0,  # 30 days
+    }
+    # Pre-existing pull cursor with coverage_start at end (the backfill boundary).
+    pull = IndividualState(individual_id="111", study_id="12345")
+    pull.coverage_start = end
+    mock_state_store[(str(integration.id), "pull_events_for_individual", "111")] = pull.dict()
+
+    # Window 1 returns one in-range event (succeeds, cursor descends to 2024-05-02);
+    # window 2's fetch raises -> abandon (incr_attempts mocked past the limit).
+    fetches = {"n": 0}
+    async def gen(**kwargs):
+        fetches["n"] += 1
+        if fetches["n"] == 1:
+            mid = kwargs["timestamp_start"] + (kwargs["timestamp_end"] - kwargs["timestamp_start"]) / 2
+            yield {"event_id": "1", "timestamp": mid.strftime("%Y-%m-%d %H:%M:%S.000"),
+                   "location_lat": "1.5", "location_long": "2.5",
+                   "individual_id": "111", "sensor_type_id": "653"}
+        else:
+            raise RuntimeError("movebank down")
+    mock_movebank_client.get_individual_events_by_time = gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.incr_attempts",
+                 AsyncMock(return_value=BACKFILL_MAX_ATTEMPTS + 1))  # over the limit -> abandon
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0,
+                                          "in_flight": 0, "pending_remaining": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "abandoned"
+    saved = mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
+    # Lowered from end (2024-06-01) to the reached floor (2024-05-02).
+    assert IndividualState.parse_obj(saved).coverage_start == datetime(2024, 5, 2, tzinfo=timezone.utc)

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -201,6 +201,33 @@ def make_counting_events_generator(events_per_call):
     return _gen, calls
 
 
+def make_windowed_events_generator(per_window, sensor_type_id="653"):
+    """Async-generator stand-in that yields `per_window` events with timestamps
+    spread INSIDE each requested [timestamp_start, timestamp_end) window, so the
+    reverse sub-action's timestamp-range keep-filter retains them. Records each
+    call's (timestamp_start, timestamp_end) in `calls['windows']`."""
+    calls = {"count": 0, "windows": []}
+
+    async def _gen(**kwargs):
+        start = kwargs["timestamp_start"]
+        end = kwargs["timestamp_end"]
+        calls["windows"].append((start, end))
+        base = calls["count"] * 100000
+        calls["count"] += 1
+        span = (end - start).total_seconds()
+        for i in range(per_window):
+            # Evenly place events strictly inside [start, end).
+            offset = span * (i + 1) / (per_window + 1)
+            ts = start + timedelta(seconds=offset)
+            yield {
+                "event_id": str(base + i),
+                "timestamp": ts.strftime("%Y-%m-%d %H:%M:%S.000"),
+                "location_lat": "1.5", "location_long": "2.5",
+                "individual_id": "111", "sensor_type_id": sensor_type_id,
+            }
+    return _gen, calls
+
+
 @pytest.mark.asyncio
 async def test_pull_events_respects_max_records_cap(
         mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
@@ -550,13 +577,13 @@ async def test_backfill_individual_retriggers_self_when_budget_exhausted(
 
 
 @pytest.mark.asyncio
-async def test_backfill_individual_sparse_sensor_reaches_end_without_livelock(
+async def test_backfill_individual_sparse_sensor_reaches_start_without_livelock(
         mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
 ):
     # A sensor that returns NO events across a multi-window range must still
-    # make bounded progress: the scan floor (`scan_from`) advances every
+    # make bounded progress: the descending cursor (`scan_from`) advances every
     # window regardless of whether events came back, so the step reaches
-    # `end` and finalizes instead of restarting at `start` forever.
+    # `start` and finalizes instead of getting stuck at `end` forever.
     from app.actions.configurations import BackfillEventsForIndividualConfig
     from datetime import datetime, timezone
     start = datetime(2024, 1, 1, tzinfo=timezone.utc)
@@ -583,59 +610,9 @@ async def test_backfill_individual_sparse_sensor_reaches_end_without_livelock(
     assert result["status"] == "completed"
     assert not mock_trigger.called  # no self re-trigger: bounded, not livelocked
     # The watermark is deleted on a successful finalize (see MINOR-4 fix) — its
-    # absence here is proof the scan floor actually reached `end` in-bounds
-    # rather than getting stuck mid-range.
+    # absence here is proof the descending cursor actually reached `start`
+    # in-bounds rather than getting stuck mid-range.
     assert (str(integration.id), "backfill_watermark", "job-1.111") not in mock_state_store
-
-
-@pytest.mark.asyncio
-async def test_backfill_individual_resumes_scan_from_persisted_floor(
-        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
-):
-    # Simulate a prior step that advanced the scan floor past `start` without
-    # ever getting an event for its sensor (so the per-sensor cursor is still
-    # unmoved, sitting at `start`). A fresh step must resume scanning from the
-    # persisted scan_from, not recompute `current` from the unmoved per-sensor
-    # cursor and rescan the already-covered span.
-    from app.actions.configurations import BackfillEventsForIndividualConfig
-    from app.actions.client import IndividualState
-    from datetime import datetime, timezone
-    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    end = datetime(2024, 1, 20, tzinfo=timezone.utc)
-    persisted_scan_from = datetime(2024, 1, 11, tzinfo=timezone.utc)  # past two 5-day windows
-    seeded_state = IndividualState(individual_id="111", study_id="12345")
-    blob = seeded_state.dict()
-    blob["scan_from"] = persisted_scan_from.isoformat()
-    mock_state_store[(str(integration.id), "backfill_watermark", "job-1.111")] = blob
-
-    captured_starts = []
-
-    async def _gen(**kwargs):
-        captured_starts.append(kwargs["timestamp_start"])
-        if False:
-            yield {}
-    mock_movebank_client.get_individual_events_by_time = _gen
-    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
-    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
-    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
-    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
-                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0, "in_flight": 0, "range": "r"}))
-    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
-    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
-    mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
-    mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
-
-    result = await action_backfill_events_for_individual(
-        integration=integration,
-        action_config=BackfillEventsForIndividualConfig(
-            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
-        ),
-    )
-
-    assert result["status"] == "completed"
-    # First fetch must start from the persisted scan floor, not from `start`
-    # (which is where the never-advanced per-sensor cursor would place it).
-    assert captured_starts[0] == persisted_scan_from
 
 
 @pytest.mark.asyncio
@@ -673,7 +650,10 @@ async def test_backfill_seeds_pull_cursor_at_end_and_finalize_merges_forward(
     assert before <= seeded_ss.latest_timestamp <= after
 
     # Now run the sub-action to completion for a small range fully in the past.
-    events = [_gps_event(42, "2025-06-01 00:00:00.000")]
+    # The event's timestamp must fall INSIDE [start, end) below: the new
+    # timestamp-range keep-filter drops anything outside the queried window
+    # (this whole 2-day range collapses into a single window).
+    events = [_gps_event(42, "2025-01-02 00:00:00.000")]
     mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
     mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
     mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
@@ -898,7 +878,7 @@ async def test_backfill_individual_stops_at_per_step_record_backstop(
     from datetime import datetime, timezone
     start = datetime(2024, 1, 1, tzinfo=timezone.utc)
     end = datetime(2025, 1, 1, tzinfo=timezone.utc)  # huge range, many windows available
-    gen, calls = make_counting_events_generator(3000)  # 3000 events/window, GPS-only
+    gen, calls = make_windowed_events_generator(3000)  # 3000 in-range events/window, GPS-only
     mock_movebank_client.get_individual_events_by_time = gen
     mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
     mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
@@ -925,12 +905,13 @@ async def test_backfill_window_over_cap_is_discarded_then_sent_after_shrink(
 ):
     # A fully-fetched over-cap window is DISCARDED (not sent); the window shrinks
     # and persists, and only a later (floor-sized) window is actually sent. With
-    # the fixed-count generator every fetch returns 3 (> cap 2), so the window
-    # shrinks to the floor in one step, then the floor window is sent anyway.
+    # the windowed generator every fetch returns 3 in-range events (> cap 2), so
+    # the window shrinks to the floor in one step, then the floor window is sent
+    # anyway. Windows now descend from `end`.
     mocker.patch("app.actions.handlers.settings.MAX_RECORDS_PER_BACKFILL_WINDOW", 2)
     mocker.patch("app.actions.handlers.settings.MIN_BACKFILL_WINDOW_SECONDS", 259200)  # 3 days
     mocker.patch("app.actions.handlers.settings.BACKFILL_WINDOW_SHRINK_SAFETY", 0.8)
-    gen, calls = make_counting_events_generator(3)  # 3 > cap 2 on every fetch
+    gen, calls = make_windowed_events_generator(3)  # 3 in-range events > cap 2 on every fetch
     mock_movebank_client.get_individual_events_by_time = gen
     send = mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
     mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
@@ -975,13 +956,16 @@ async def test_backfill_honours_persisted_window_seconds(
         mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
 ):
     # A persisted window_seconds from a prior step is used instead of the density
-    # estimate: the sub-action queries with end_at = current + persisted window.
+    # estimate: in reverse, the sub-action queries with timestamp_start ==
+    # cursor - persisted window. scan_from is one minute past `start` so the
+    # descending cursor has room to take a 60s window without clamping to start.
     st = IndividualState(individual_id="111", study_id="12345")
     mock_state_store[(str(integration.id), "backfill_watermark", "job-x.111")] = {
-        **st.dict(), "scan_from": "2024-01-01T00:00:00+00:00", "window_seconds": 60.0,
+        **st.dict(), "scan_from": "2024-01-01T00:01:00+00:00", "window_seconds": 60.0,
     }
-    ends = []
+    starts, ends = [], []
     def gen(**kwargs):
+        starts.append(kwargs.get("timestamp_start"))
         ends.append(kwargs.get("timestamp_end"))
         async def _agen():
             for _ in ():
@@ -1008,7 +992,8 @@ async def test_backfill_honours_persisted_window_seconds(
         ),
     )
 
-    # First window ends 60s after the persisted scan_from, not 5 days later.
+    # First window is [scan_from - 60s, scan_from), not a 5-day-wide window.
+    assert starts[0] == datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
     assert ends[0] == datetime(2024, 1, 1, 0, 1, tzinfo=timezone.utc)
 
 
@@ -1623,8 +1608,9 @@ async def test_backfill_cancelled_step_reraises_and_preserves_scan_from(
 ):
     # A hard cancellation mid-send must propagate (CancelledError is BaseException,
     # not caught by the retry/backoff handlers) and must not have advanced the
-    # persisted scan_from past what was durably completed.
-    gen, _calls = make_counting_events_generator(1)  # 1 event/fetch, under the cap
+    # persisted scan_from past what was durably completed. Needs an in-range
+    # event (kept by the timestamp keep-filter) so send is actually reached.
+    gen, _calls = make_windowed_events_generator(1)  # 1 in-range event/fetch, under the cap
     mock_movebank_client.get_individual_events_by_time = gen
     mocker.patch("app.actions.handlers.send_observations_to_gundi",
                  AsyncMock(side_effect=asyncio.CancelledError()))
@@ -1714,3 +1700,128 @@ async def test_backfill_default_still_bails_when_job_active(
 
     assert result.get("already_active") is True
     assert not clear.called
+
+
+@pytest.mark.asyncio
+async def test_backfill_processes_recent_window_first(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # Reverse: the FIRST window queried is the most recent one, [end - window, end).
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 31, tzinfo=timezone.utc)
+    gen, calls = make_windowed_events_generator(1)
+    mock_movebank_client.get_individual_events_by_time = gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    for m in ("record_completion", "decr_in_flight", "reset_attempts"):
+        mocker.patch(f"app.actions.backfill_queue.BackfillJob.{m}", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0,
+                                          "in_flight": 0, "pending_remaining": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual={**INDIVIDUAL_ROW, "number_of_events": "60000"},
+            job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "completed"
+    first_lower, first_upper = calls["windows"][0]
+    assert first_upper == end                      # started at the most recent edge
+    assert first_lower > start                     # first window is a recent slice, not the whole range
+    # windows strictly descend and tile down to start with no gap/overlap
+    lowers = [w[0] for w in calls["windows"]]
+    uppers = [w[1] for w in calls["windows"]]
+    assert uppers[1:] == lowers[:-1]               # each window's upper == previous window's lower
+    assert min(lowers) == start                     # reached start
+
+
+@pytest.mark.asyncio
+async def test_backfill_timestamp_ownership_no_dup_across_boundary(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # An event exactly at a window boundary, and the accessory 60-min pre-roll,
+    # must each be emitted by exactly one window (no dup, no gap). We drive real
+    # source-id collection through send and assert uniqueness.
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 11, tzinfo=timezone.utc)
+
+    # Generator returns the SAME fixed set every call (like the real client's
+    # range-agnostic over-fetch): three events, one on a window boundary.
+    boundary = datetime(2024, 1, 6, tzinfo=timezone.utc)
+    fixed = [
+        {"event_id": "1", "timestamp": "2024-01-03 12:00:00.000", "location_lat": "1.5",
+         "location_long": "2.5", "individual_id": "111", "sensor_type_id": "653"},
+        {"event_id": "2", "timestamp": boundary.strftime("%Y-%m-%d %H:%M:%S.000"), "location_lat": "1.5",
+         "location_long": "2.5", "individual_id": "111", "sensor_type_id": "653"},
+        {"event_id": "3", "timestamp": "2024-01-08 12:00:00.000", "location_lat": "1.5",
+         "location_long": "2.5", "individual_id": "111", "sensor_type_id": "653"},
+    ]
+    async def gen(**kwargs):
+        for e in fixed:
+            yield e
+    mock_movebank_client.get_individual_events_by_time = gen
+    sent_ids = []
+    async def capture(observations, **kwargs):
+        sent_ids.extend(o["additional"]["event_id"] for o in observations)
+        return []
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(side_effect=capture))
+    mocker.patch("app.actions.handlers.settings.MIN_BACKFILL_WINDOW_SECONDS", 60)
+    for m in ("record_completion", "decr_in_flight", "reset_attempts"):
+        mocker.patch(f"app.actions.backfill_queue.BackfillJob.{m}", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0,
+                                          "in_flight": 0, "pending_remaining": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+
+    await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual={**INDIVIDUAL_ROW, "number_of_events": "1000"},
+            job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    # Each of the three in-range events emitted exactly once (boundary event not doubled).
+    assert sorted(sent_ids) == ["1", "2", "3"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_resumes_from_persisted_descending_cursor(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # A persisted scan_from (descending cursor) resumes the descent: the first
+    # window queried is [scan_from - window, scan_from), not [end - window, end).
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    st = IndividualState(individual_id="111", study_id="12345")
+    mock_state_store[(str(integration.id), "backfill_watermark", "job-1.111")] = {
+        **st.dict(), "scan_from": "2024-06-01T00:00:00+00:00", "window_seconds": 86400.0,  # 1-day window
+    }
+    gen, calls = make_windowed_events_generator(0)
+    mock_movebank_client.get_individual_events_by_time = gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    for m in ("record_completion", "decr_in_flight", "reset_attempts"):
+        mocker.patch(f"app.actions.backfill_queue.BackfillJob.{m}", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0,
+                                          "in_flight": 0, "pending_remaining": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+
+    await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1",
+            start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 12, 1, tzinfo=timezone.utc),
+        ),
+    )
+
+    assert calls["windows"][0][1] == datetime(2024, 6, 1, tzinfo=timezone.utc)          # resumed at scan_from
+    assert calls["windows"][0][0] == datetime(2024, 5, 31, tzinfo=timezone.utc)         # one 1-day window down

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -2088,3 +2088,39 @@ async def test_backfill_abandon_lowers_coverage_start_to_reached_floor(
     # The recent window's event-id was merged FORWARD into the pull cursor so the
     # pull's accessory settling re-read dedups the seam (not just coverage_start).
     assert merged.sensor_states["653"].highest_event_id == 1
+
+
+@pytest.mark.asyncio
+async def test_merge_into_pull_cursor_skips_write_when_unchanged(mocker, integration):
+    # The merge shares the pull cursor key with the scheduled pull, so it must
+    # NOT set_state when nothing actually changes (a needless write is another
+    # TOCTOU chance to clobber a concurrent pull advance).
+    from app.actions.handlers import _merge_backfill_into_pull_cursor
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    end = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    existing = IndividualState(individual_id="111", study_id="12345")
+    existing.coverage_start = end
+    existing.update_sensor_state(653, end, 10)
+    mocker.patch("app.actions.handlers.state_manager.get_state", AsyncMock(return_value=existing.dict()))
+    set_state = mocker.patch("app.actions.handlers.state_manager.set_state", AsyncMock())
+
+    # Backfill maxima are <= existing and the floor is not below existing coverage_start.
+    bf = IndividualState(individual_id="111", study_id="12345")
+    bf.update_sensor_state(653, end, 5)
+    cfg = BackfillEventsForIndividualConfig(
+        study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1",
+        start=datetime(2024, 1, 1, tzinfo=timezone.utc), end=end,
+    )
+    await _merge_backfill_into_pull_cursor(
+        str(integration.id), _make_individual(), cfg, bf,
+        coverage_start=end, lower_only=True, create_if_missing=False,
+    )
+    assert not set_state.called  # nothing moved -> no write
+
+    # A real advance (higher event-id) DOES write.
+    bf.update_sensor_state(653, end, 99)
+    await _merge_backfill_into_pull_cursor(
+        str(integration.id), _make_individual(), cfg, bf,
+        coverage_start=end, lower_only=True, create_if_missing=False,
+    )
+    assert set_state.called

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1007,6 +1007,12 @@ async def test_backfill_individual_checks_deadline_between_sensor_fetches(
     # Uses a real (tiny) deadline and a real sleep on the first sensor's fetch
     # rather than mocking time.monotonic, which asyncio's own loop internals
     # also call (mocking it globally breaks the event loop itself).
+    #
+    # The first sensor's fetch DOES return an event before the deadline is hit
+    # on the second sensor. The whole window must be discarded (not partially
+    # sent) — see test_backfill_individual_resumed_window_does_not_duplicate_
+    # sensor_already_fetched below for the duplicate-send regression this
+    # atomicity guards against.
     import asyncio
     from app.actions.configurations import BackfillEventsForIndividualConfig
     from datetime import datetime, timezone
@@ -1018,12 +1024,11 @@ async def test_backfill_individual_checks_deadline_between_sensor_fetches(
         if kwargs["sensor_type_ids"] == [653]:
             calls["gps"] += 1
             await asyncio.sleep(0.1)  # simulate a slow first-sensor request
+            yield _gps_event(1, "2024-01-02 12:00:00.000")
         else:
             calls["accessory"] += 1
-        if False:
-            yield {}
     mock_movebank_client.get_individual_events_by_time = _gen
-    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mock_send = mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
     mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
     # A tiny real budget: comfortably survives until after the GPS fetch is
     # requested, but is exhausted by the time the 0.1s sleep completes.
@@ -1043,6 +1048,81 @@ async def test_backfill_individual_checks_deadline_between_sensor_fetches(
     assert calls["gps"] == 1
     assert calls["accessory"] == 0  # deadline hit before this sensor's fetch
     assert mock_trigger.await_count == 1
+    # Discard-on-interrupt: the GPS event already fetched must NOT be sent,
+    # and no scan_from/window_seconds is persisted for the (retried) window —
+    # the whole window, including the sensor already fetched, is redone.
+    assert mock_send.await_count == 0
+    assert mock_state_store.get((str(integration.id), "backfill_watermark", "job-1.111")) is None
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_resumed_window_does_not_duplicate_sensor_already_fetched(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # Regression for the reverse-backfill duplicate-send bug: when the
+    # deadline hits between a window's per-sensor fetches, the whole window
+    # must be discarded (not partially sent). Call 1's GPS fetch succeeds but
+    # the accessory fetch is cut off by the deadline; call 2 then resumes the
+    # (unmoved) cursor and re-fetches BOTH sensors over the identical window.
+    # If the window were partially sent on call 1 (the bug), the GPS event
+    # would be sent again on call 2 -> a duplicate observation.
+    import asyncio
+    from datetime import datetime, timezone
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 3, tzinfo=timezone.utc)
+    call_state = {"slow_first_fetch": True}
+
+    async def _gen(**kwargs):
+        stid = kwargs["sensor_type_ids"][0]
+        if stid == 653:  # gps
+            if call_state["slow_first_fetch"]:
+                await asyncio.sleep(0.1)  # call 1 only: blow the deadline mid-window
+            yield _gps_event(1, "2024-01-02 12:00:00.000")
+        else:  # accessory-measurements
+            yield {
+                "event_id": "2", "timestamp": "2024-01-02 12:00:00.000",
+                "individual_id": "111", "sensor_type_id": str(stid),
+                "location_lat": "1.5", "location_long": "2.5",
+            }
+    mock_movebank_client.get_individual_events_by_time = _gen
+
+    sent_event_ids = []
+
+    async def _send(observations, integration_id):
+        sent_event_ids.extend(o["additional"]["event_id"] for o in observations)
+        return []
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(side_effect=_send))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.reset_attempts", AsyncMock())
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 2, "in_flight": 0, "range": "r"}))
+
+    config = BackfillEventsForIndividualConfig(
+        study_id="12345",
+        individual={**INDIVIDUAL_ROW, "sensor_type_ids": "gps,accessory-measurements"},
+        job_id="job-1", start=start, end=end,
+    )
+
+    # Call 1: deadline hits between sensors -> window discarded whole, cursor
+    # unmoved, nothing sent.
+    mocker.patch("app.actions.handlers.settings.MAX_ACTION_EXECUTION_TIME", 0.01)
+    result1 = await action_backfill_events_for_individual(integration=integration, action_config=config)
+    assert result1["status"] == "continued"
+    assert sent_event_ids == []
+
+    # Call 2: resumes at the SAME (unmoved) cursor with a generous deadline,
+    # so both sensors fetch successfully this time.
+    call_state["slow_first_fetch"] = False
+    mocker.patch("app.actions.handlers.settings.MAX_ACTION_EXECUTION_TIME", 100)
+    await action_backfill_events_for_individual(integration=integration, action_config=config)
+
+    # The gps sensor's event ("1") must be sent exactly once across both
+    # calls — not duplicated because call 1 partially sent the window.
+    assert sent_event_ids.count("1") == 1
+    assert sent_event_ids.count("2") == 1
 
 
 @pytest.mark.asyncio

--- a/docs/superpowers/plans/2026-07-23-backfill-recent-first.md
+++ b/docs/superpowers/plans/2026-07-23-backfill-recent-first.md
@@ -1,0 +1,559 @@
+# Recent-First (Reverse-Chronological) Backfill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make backfill process `[start, coverage_start)` newest-window-first so recent history reaches EarthRanger first, replacing the event-id dedup floor with exact timestamp-range ownership.
+
+**Architecture:** Reverse the sub-action's scan so a `cursor` descends from `end` to `start`; each window `[max(start, cursor − window), cursor)` fetches its sensors, keeps only events whose timestamp lies in that half-open range (dropping the client's accessory pre-roll and second-truncation over-fetch), sends them, and descends. Durable per-window progress stays in the backfill watermark; the pull-facing `coverage_start` reconciles only at finalize (success → `start`; abandon → reached floor).
+
+**Tech Stack:** Python 3.10, pydantic v1, redis.asyncio, pytest + pytest-asyncio + pytest-mock + respx. Tests run in Docker `mb-runner-test`.
+
+## Global Constraints
+
+- Python 3.10, pydantic v1.
+- Branch: `movebank-backfill-recent-first` (off `main`, base `f669398`). Commit on top; no new branch.
+- Test command: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app -q`. Focused: append the path / `-k`. Never run pytest outside Docker.
+- **Reverse replaces forward** — there is no direction config.
+- **The window is the atomic unit**; sent in full or discarded in full. Reverse uses **timestamp-range ownership** for dedup: keep only events with `window_lower <= ts < window_upper` (half-open). No `event_id` floor (`minimum_event_id = 0`); no accessory settling widening in backfill.
+- Backfill touches only settled historical data (`coverage_start ≈ now − maximum_lookback_hours`; every window is older than `ACCESSORY_SETTLING_HOURS = 12h`), so dropping the accessory re-read loses nothing.
+- The per-window overflow cap / per-step backstop count **kept** (in-range) events, not raw fetched rows.
+- `coverage_start` is written to the pull cursor ONLY at finalize (success → `action_config.start`; abandon → reached floor). NEVER per window (avoids multiplying the pull-cursor TOCTOU).
+- Unchanged: step budget + discard/shrink + `window_seconds`; `CancelledError` backstop; `restart`; `_seed_pull_cursor_at_end`; the steady-state pull and its `_query_start_for_sensor` / `minimum_event_id` use; `_compute_batch_window`; `_advance_watermarks` (kept as-is — its output is vestigial in reverse, feeding only the inert finalize merge); `coverage_start` storage (an `IndividualState` field); `BackfillConfig`.
+- Constants (unchanged): `MAX_RECORDS_PER_BACKFILL_WINDOW=5000`, `MIN_BACKFILL_WINDOW_SECONDS=300`, `BACKFILL_WINDOW_SHRINK_SAFETY=0.8`, `MAX_RECORDS_PER_BACKFILL_STEP=10000`, `OBSERVATIONS_BATCH_SIZE=200`, `BACKFILL_MAX_ATTEMPTS=5`.
+
+## File Structure
+
+- `app/actions/handlers.py` — `action_backfill_events_for_individual` (reverse loop + keep-filter); `_finalize_backfill_individual` + a new `_record_abandoned_coverage` helper (Task 2).
+- `app/actions/tests/test_handlers.py` — a new windowed-events generator, new reverse tests, and reconciliation of the existing forward sub-action tests.
+
+---
+
+### Task 1: Reverse the sub-action traversal with timestamp-range ownership
+
+**Files:**
+- Modify: `app/actions/handlers.py` (`action_backfill_events_for_individual`, roughly lines 702–860)
+- Test: `app/actions/tests/test_handlers.py` (new helper + new tests + reconcile existing)
+
+**Interfaces:**
+- Consumes: `_ensure_utc`, `parse_date`, `build_observation`, `send_observations_to_gundi`, `_advance_watermarks`, `settings.*` caps.
+- Produces: backfill fills `[start, end)` newest-window-first; the watermark blob's `scan_from` is the descending cursor (we have covered `[scan_from, end)`); each event is emitted by exactly the window whose `[lower, upper)` contains its timestamp.
+
+- [ ] **Step 1: Add a windowed-events generator to the test module**
+
+The existing `make_counting_events_generator` / `make_events_generator` yield events with fixed timestamps that ignore the query range — incompatible with the new keep-filter. Add near the other generators in `app/actions/tests/test_handlers.py`:
+
+```python
+def make_windowed_events_generator(per_window, sensor_type_id="653"):
+    """Async-generator stand-in that yields `per_window` events with timestamps
+    spread INSIDE each requested [timestamp_start, timestamp_end) window, so the
+    reverse sub-action's timestamp-range keep-filter retains them. Records each
+    call's (timestamp_start, timestamp_end) in `calls['windows']`."""
+    calls = {"count": 0, "windows": []}
+
+    async def _gen(**kwargs):
+        start = kwargs["timestamp_start"]
+        end = kwargs["timestamp_end"]
+        calls["windows"].append((start, end))
+        base = calls["count"] * 100000
+        calls["count"] += 1
+        span = (end - start).total_seconds()
+        for i in range(per_window):
+            # Evenly place events strictly inside [start, end).
+            offset = span * (i + 1) / (per_window + 1)
+            ts = start + timedelta(seconds=offset)
+            yield {
+                "event_id": str(base + i),
+                "timestamp": ts.strftime("%Y-%m-%d %H:%M:%S.000"),
+                "location_lat": "1.5", "location_long": "2.5",
+                "individual_id": "111", "sensor_type_id": sensor_type_id,
+            }
+    return _gen, calls
+```
+
+- [ ] **Step 2: Write the failing reverse tests**
+
+Append to `app/actions/tests/test_handlers.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_backfill_processes_recent_window_first(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # Reverse: the FIRST window queried is the most recent one, [end - window, end).
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 31, tzinfo=timezone.utc)
+    gen, calls = make_windowed_events_generator(1)
+    mock_movebank_client.get_individual_events_by_time = gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    for m in ("record_completion", "decr_in_flight", "reset_attempts"):
+        mocker.patch(f"app.actions.backfill_queue.BackfillJob.{m}", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0,
+                                          "in_flight": 0, "pending_remaining": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual={**INDIVIDUAL_ROW, "number_of_events": "60000"},
+            job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "completed"
+    first_lower, first_upper = calls["windows"][0]
+    assert first_upper == end                      # started at the most recent edge
+    assert first_lower > start                     # first window is a recent slice, not the whole range
+    # windows strictly descend and tile down to start with no gap/overlap
+    lowers = [w[0] for w in calls["windows"]]
+    uppers = [w[1] for w in calls["windows"]]
+    assert uppers[1:] == lowers[:-1]               # each window's upper == previous window's lower
+    assert min(lowers) == start                     # reached start
+
+
+@pytest.mark.asyncio
+async def test_backfill_timestamp_ownership_no_dup_across_boundary(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # An event exactly at a window boundary, and the accessory 60-min pre-roll,
+    # must each be emitted by exactly one window (no dup, no gap). We drive real
+    # source-id collection through send and assert uniqueness.
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 11, tzinfo=timezone.utc)
+
+    # Generator returns the SAME fixed set every call (like the real client's
+    # range-agnostic over-fetch): three events, one on a window boundary.
+    boundary = datetime(2024, 1, 6, tzinfo=timezone.utc)
+    fixed = [
+        {"event_id": "1", "timestamp": "2024-01-03 12:00:00.000", "location_lat": "1.5",
+         "location_long": "2.5", "individual_id": "111", "sensor_type_id": "653"},
+        {"event_id": "2", "timestamp": boundary.strftime("%Y-%m-%d %H:%M:%S.000"), "location_lat": "1.5",
+         "location_long": "2.5", "individual_id": "111", "sensor_type_id": "653"},
+        {"event_id": "3", "timestamp": "2024-01-08 12:00:00.000", "location_lat": "1.5",
+         "location_long": "2.5", "individual_id": "111", "sensor_type_id": "653"},
+    ]
+    async def gen(**kwargs):
+        for e in fixed:
+            yield e
+    mock_movebank_client.get_individual_events_by_time = gen
+    sent_ids = []
+    async def capture(observations, **kwargs):
+        sent_ids.extend(o["additional"]["event_id"] for o in observations)
+        return []
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(side_effect=capture))
+    mocker.patch("app.actions.handlers.settings.MIN_BACKFILL_WINDOW_SECONDS", 60)
+    for m in ("record_completion", "decr_in_flight", "reset_attempts"):
+        mocker.patch(f"app.actions.backfill_queue.BackfillJob.{m}", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0,
+                                          "in_flight": 0, "pending_remaining": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+
+    await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual={**INDIVIDUAL_ROW, "number_of_events": "1000"},
+            job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    # Each of the three in-range events emitted exactly once (boundary event not doubled).
+    assert sorted(sent_ids) == ["1", "2", "3"]
+
+
+@pytest.mark.asyncio
+async def test_backfill_resumes_from_persisted_descending_cursor(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # A persisted scan_from (descending cursor) resumes the descent: the first
+    # window queried is [scan_from - window, scan_from), not [end - window, end).
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    st = IndividualState(individual_id="111", study_id="12345")
+    mock_state_store[(str(integration.id), "backfill_watermark", "job-1.111")] = {
+        **st.dict(), "scan_from": "2024-06-01T00:00:00+00:00", "window_seconds": 86400.0,  # 1-day window
+    }
+    gen, calls = make_windowed_events_generator(0)
+    mock_movebank_client.get_individual_events_by_time = gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    for m in ("record_completion", "decr_in_flight", "reset_attempts"):
+        mocker.patch(f"app.actions.backfill_queue.BackfillJob.{m}", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0,
+                                          "in_flight": 0, "pending_remaining": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+
+    await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1",
+            start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            end=datetime(2024, 12, 1, tzinfo=timezone.utc),
+        ),
+    )
+
+    assert calls["windows"][0][1] == datetime(2024, 6, 1, tzinfo=timezone.utc)          # resumed at scan_from
+    assert calls["windows"][0][0] == datetime(2024, 5, 31, tzinfo=timezone.utc)         # one 1-day window down
+```
+
+- [ ] **Step 3: Run the new tests to verify they fail**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_handlers.py -k "recent_window_first or timestamp_ownership or resumes_from_persisted_descending" -q`
+Expected: FAIL — the current forward loop queries `[start …]` upward, so the first window's `timestamp_upper` is not `end`, and the boundary/ownership assertions don't hold.
+
+- [ ] **Step 4: Implement the reverse loop**
+
+In `action_backfill_events_for_individual`, replace the window-setup and the whole `while` loop (currently ~702–814) with the reverse version. Keep the surrounding `try` / `except` structure; only the loop body and the initial `cursor` change here (the `except`/completion tail changes in the next steps).
+
+Replace the setup line that computes the initial position (`current = persisted_scan_from if persisted_scan_from is not None else min(sensor_type_timestamps.values())`) with:
+
+```python
+    # Reverse (recent-first): `cursor` is the LOWER edge of coverage so far — we
+    # have covered [cursor, end) and still owe [start, cursor). It begins at
+    # `end` (= coverage_start) and descends toward `start`; a persisted position
+    # resumes the descent. (The backfill watermark's scan_from stores it.)
+    cursor = persisted_scan_from if persisted_scan_from is not None else action_config.end
+```
+
+Replace the loop body:
+
+```python
+    try:
+        async with mb_client as mb:
+            while cursor > action_config.start and time.monotonic() < deadline:
+                window_lower = max(action_config.start, cursor - window)
+                window_upper = cursor
+                events = []
+                window_interrupted = False
+                for stid in sensor_type_ids:
+                    if time.monotonic() >= deadline:
+                        window_interrupted = True
+                        break
+                    async with movebank_slot(auth_config.username):
+                        async for event in mb.get_individual_events_by_time(
+                            study_id=action_config.study_id, individual_id=ind.id,
+                            timestamp_start=window_lower, timestamp_end=window_upper,
+                            sensor_type_ids=[stid], minimum_event_id=0,
+                        ):
+                            events.append(event)
+
+                # Timestamp-range ownership: keep only events whose timestamp is
+                # in this window's half-open [lower, upper). Discards the client's
+                # accessory 60-min pre-roll and the whole-second timestamp_end
+                # truncation, so each event belongs to exactly one window and no
+                # cross-window event-id dedup is needed. Unparseable timestamps
+                # are dropped (build_observation would drop them anyway).
+                kept = []
+                for e in events:
+                    try:
+                        ts = _ensure_utc(parse_date(e.get("timestamp")))
+                    except Exception:
+                        continue
+                    if window_lower <= ts < window_upper:
+                        kept.append(e)
+
+                # Overflow guard on KEPT (send) volume — see step-budget design.
+                if (not window_interrupted
+                        and len(kept) > settings.MAX_RECORDS_PER_BACKFILL_WINDOW
+                        and window > min_window):
+                    shrunk = (window.total_seconds()
+                              * settings.MAX_RECORDS_PER_BACKFILL_WINDOW / len(kept)
+                              * settings.BACKFILL_WINDOW_SHRINK_SAFETY)
+                    window = max(min_window, timedelta(seconds=shrunk))
+                    blob = json.loads(state.json())
+                    blob["scan_from"] = cursor.isoformat()           # unchanged (cursor not advanced)
+                    blob["window_seconds"] = window.total_seconds()
+                    await state_manager.set_state(integration_id, BACKFILL_WATERMARK_ACTION_ID,
+                                                  blob, source_id=watermark_source)
+                    logger.info(
+                        f"Backfill {log_reference}: window over cap "
+                        f"({len(kept)} > {settings.MAX_RECORDS_PER_BACKFILL_WINDOW}); "
+                        f"shrunk to {window.total_seconds():.0f}s, retrying"
+                    )
+                    continue
+                if (not window_interrupted
+                        and len(kept) > settings.MAX_RECORDS_PER_BACKFILL_WINDOW):
+                    logger.warning(
+                        f"Backfill {log_reference}: window at floor "
+                        f"({settings.MIN_BACKFILL_WINDOW_SECONDS}s) still over cap "
+                        f"({len(kept)} events); sending anyway"
+                    )
+
+                device_name = _display_name(ind)
+                observations = [o for e in kept if (o := build_observation(event=e, device_name=device_name)) is not None]
+                for batch in chunks(observations, OBSERVATIONS_BATCH_SIZE):
+                    await send_observations_to_gundi(observations=batch, integration_id=integration_id)
+
+                # Vestigial in reverse: advances per-sensor state from the kept
+                # events. Used only by the finalize forward-merge, which is inert
+                # here (backfill's max is below coverage_start). Kept for parity
+                # and harmless (may reflect the oldest window's values).
+                _advance_watermarks(state, kept, sensor_type_ids, sensor_type_timestamps, minimum_event_ids)
+                observations_sent += len(observations)
+                if not window_interrupted:
+                    cursor = window_lower       # descend
+
+                blob = json.loads(state.json())
+                blob["scan_from"] = cursor.isoformat()
+                blob["window_seconds"] = window.total_seconds()
+                await state_manager.set_state(integration_id, BACKFILL_WATERMARK_ACTION_ID,
+                                              blob, source_id=watermark_source)
+
+                if window_interrupted or observations_sent >= MAX_RECORDS_PER_BACKFILL_STEP:
+                    break
+```
+
+Update the `except asyncio.CancelledError` log to reference `cursor` instead of `current`:
+
+```python
+        logger.warning(
+            f"Backfill {log_reference}: step hard-cancelled at scan_from={cursor.isoformat()}; "
+            "resume on next trigger or re-run with restart=true"
+        )
+```
+
+Update the completion check at the tail (currently `if current < action_config.end:`):
+
+```python
+    if cursor > action_config.start:
+        # Budget exhausted mid-range: continue THIS individual on the next step
+        # (descending from the persisted cursor).
+        await trigger_action(
+            integration_id=integration_id, action_id=BACKFILL_ACTION_ID, config=action_config,
+        )
+        logger.info(f"Backfill {log_reference} continued at {cursor.isoformat()} ({observations_sent} obs this step)")
+        return {"status": "continued", "observations_sent": observations_sent}
+
+    return await _finalize_backfill_individual(
+        integration_id, job, ind, action_config, observations=observations_sent, state=state
+    )
+```
+
+Also update the `persisted_scan_from` comment block (~689–694) to describe a descending cursor rather than an ascending floor (semantics: "we have covered `[scan_from, end)`").
+
+- [ ] **Step 5: Run the new tests to verify they pass**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_handlers.py -k "recent_window_first or timestamp_ownership or resumes_from_persisted_descending" -q`
+Expected: PASS.
+
+- [ ] **Step 6: Reconcile the existing forward sub-action tests**
+
+The keep-filter and the reversed traversal break tests that (a) use fixed-timestamp generators whose events fall outside the queried windows, or (b) assert forward-specific window bounds / positions. Run the backfill sub-action set and fix each failure, preserving the test's original intent:
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_handlers.py -k "backfill_individual or over_cap or honours_persisted or cancelled_step" -q`
+
+Known tests to update (verify against actual results):
+- `test_backfill_individual_density_window_applies` — 0-event generator; asserts window *count*. Reverse tiles the same 30-day range at the same window size → same count (12). Likely passes; if the count differs by one due to the descending clamp at `start`, update the expected count to the observed tiling.
+- `test_backfill_individual_stops_at_per_step_record_backstop` — uses `make_counting_events_generator(3000)` with a fixed 2026 timestamp far outside the 2024 range → all dropped by the keep-filter. Switch to `make_windowed_events_generator(3000)` so 3000 in-range events are kept per window; keep the assertion that the per-step backstop stops after `ceil(10000/3000)=4` windows (`observations_sent == 12000`, one `trigger_action`).
+- `test_backfill_individual_checks_deadline_between_sensor_fetches` — deadline mechanics are direction-agnostic; if it asserts a specific window bound, flip it to the descending first window `[end - window, end)`.
+- `test_backfill_individual_resumes_scan_from_persisted_floor` — forward-resume semantics; supersede/rename to the descending-resume behavior already covered by `test_backfill_resumes_from_persisted_descending_cursor` (delete this forward-only test or convert it).
+- `test_backfill_individual_sparse_sensor_reaches_end_without_livelock` — forward "reaches end"; convert to reverse "reaches start" (cursor descends to `start`, no livelock) using `make_windowed_events_generator(0)`.
+- `test_backfill_window_over_cap_is_discarded_then_sent_after_shrink` — uses `make_counting_events_generator(3)` (fixed 2026 ts). Switch to `make_windowed_events_generator(3)` so 3 in-range events are kept and exceed the patched cap of 2; keep the discard-then-shrink assertions (`calls["count"] == 2`, `send.call_count == 1`, persisted `window_seconds == floor`). Note windows now descend from `end`.
+- `test_backfill_honours_persisted_window_seconds` — asserts the first window's `timestamp_end`. In reverse the first window is `[scan_from - 60s, scan_from)`; update the assertion to `timestamp_start == scan_from - 60s` and `timestamp_end == scan_from` (it already patches `MIN_BACKFILL_WINDOW_SECONDS`).
+- `test_backfill_individual_retriggers_self_when_budget_exhausted` — "continued when current<end" → "continued when cursor>start"; adjust any position assertion to the descending cursor.
+- Tests that are direction-agnostic and should pass unchanged (verify): `..._acquires_connection_slot`, `..._finalizes_and_dispatches_next`, `..._backs_off_when_no_slot`, `..._abandoned_after_max_attempts`, `..._finalize_error_is_not_misclassified...`, `..._resets_attempts_after_successful_step`, `..._seeds_pull_cursor_at_end_and_finalize_merges_forward`, `test_backfill_cancelled_step_reraises_and_preserves_scan_from`.
+
+For each test you change, note the change and why in the report.
+
+- [ ] **Step 7: Full suite + commit**
+
+```bash
+docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app -q
+git add app/actions/handlers.py app/actions/tests/test_handlers.py
+git commit -m "feat: reverse-chronological backfill with timestamp-range ownership"
+```
+
+---
+
+### Task 2: Abandon-path `coverage_start` = reached floor
+
+**Files:**
+- Modify: `app/actions/handlers.py` (new `_record_abandoned_coverage` helper; call it in the abandon branch of `action_backfill_events_for_individual`)
+- Test: `app/actions/tests/test_handlers.py` (append)
+
+**Interfaces:**
+- Consumes: `state_manager`, `CURSOR_STATE_ACTION_ID`, `IndividualState`.
+- Produces: on abandon (after `BACKFILL_MAX_ATTEMPTS`), the pull cursor's `coverage_start` is lowered to the reached floor (`cursor`), so an abandoned reverse job records how far back it actually covered. Success finalize is unchanged (`= start`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `app/actions/tests/test_handlers.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_backfill_abandon_lowers_coverage_start_to_reached_floor(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # One window completes (cursor descends), then fetches fail and the
+    # individual is abandoned; coverage_start must be LOWERED to the reached
+    # floor (the descended cursor), not left at its original value.
+    from app.actions.handlers import BACKFILL_MAX_ATTEMPTS
+    from app.actions.configurations import BackfillEventsForIndividualConfig
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 6, 1, tzinfo=timezone.utc)
+    # A 30-day window means the first window is [end - 30d, end) = [2024-05-02, 2024-06-01).
+    st = IndividualState(individual_id="111", study_id="12345")
+    mock_state_store[(str(integration.id), "backfill_watermark", "job-1.111")] = {
+        **st.dict(), "window_seconds": 2592000.0,  # 30 days
+    }
+    # Pre-existing pull cursor with coverage_start at end (the backfill boundary).
+    pull = IndividualState(individual_id="111", study_id="12345")
+    pull.coverage_start = end
+    mock_state_store[(str(integration.id), "pull_events_for_individual", "111")] = pull.dict()
+
+    # Window 1 returns one in-range event (succeeds, cursor descends to 2024-05-02);
+    # window 2's fetch raises -> abandon (incr_attempts mocked past the limit).
+    fetches = {"n": 0}
+    async def gen(**kwargs):
+        fetches["n"] += 1
+        if fetches["n"] == 1:
+            mid = kwargs["timestamp_start"] + (kwargs["timestamp_end"] - kwargs["timestamp_start"]) / 2
+            yield {"event_id": "1", "timestamp": mid.strftime("%Y-%m-%d %H:%M:%S.000"),
+                   "location_lat": "1.5", "location_long": "2.5",
+                   "individual_id": "111", "sensor_type_id": "653"}
+        else:
+            raise RuntimeError("movebank down")
+    mock_movebank_client.get_individual_events_by_time = gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.incr_attempts",
+                 AsyncMock(return_value=BACKFILL_MAX_ATTEMPTS + 1))  # over the limit -> abandon
+    mocker.patch("app.actions.backfill_queue.BackfillJob.record_completion", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_done", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 1, "observations_sent": 0,
+                                          "in_flight": 0, "pending_remaining": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "abandoned"
+    saved = mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
+    # Lowered from end (2024-06-01) to the reached floor (2024-05-02).
+    assert IndividualState.parse_obj(saved).coverage_start == datetime(2024, 5, 2, tzinfo=timezone.utc)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_handlers.py -k abandon_lowers_coverage_start -q`
+Expected: FAIL — today's abandon path leaves the pull cursor untouched, so `coverage_start` keeps whatever it was (here it happens to equal `end`, but nothing writes it; assert-write fails if the cursor object isn't re-written) — confirm the failure is that `coverage_start` isn't reconciled on abandon.
+
+- [ ] **Step 3: Implement**
+
+Add the helper near `_finalize_backfill_individual` in `app/actions/handlers.py`:
+
+```python
+async def _record_abandoned_coverage(integration_id, ind, action_config, floor):
+    """On abandon, lower the pull cursor's coverage_start to the reached floor so
+    the recent portion a reverse backfill DID cover is recorded (a later fresh
+    backfill sees a smaller remaining range). Single best-effort write on a rare
+    path; preserves the pull's sensor cursors as read."""
+    raw = await state_manager.get_state(integration_id, CURSOR_STATE_ACTION_ID, source_id=ind.id)
+    existing = IndividualState.parse_obj(raw) if raw else IndividualState(
+        individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
+    )
+    if existing.coverage_start is None or floor < existing.coverage_start:
+        existing.coverage_start = floor
+    await state_manager.set_state(integration_id, CURSOR_STATE_ACTION_ID,
+                                  json.loads(existing.json()), source_id=ind.id)
+```
+
+In `action_backfill_events_for_individual`, the abandon branch (inside `except Exception`, when `attempts > BACKFILL_MAX_ATTEMPTS`) — add the coverage record before finalize:
+
+```python
+        logger.warning(f"Backfill {action_config.job_id}/{ind.id}: abandoned after {attempts} attempts: {exc}")
+        await _record_abandoned_coverage(integration_id, ind, action_config, floor=cursor)
+        result = await _finalize_backfill_individual(integration_id, job, ind, action_config, observations=0)
+        return {"status": "abandoned", **{k: v for k, v in result.items() if k != "status"}}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app/actions/tests/test_handlers.py -k abandon_lowers_coverage_start -q`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite + commit**
+
+```bash
+docker run --rm -v "$PWD/app":/code/app -w /code mb-runner-test python -m pytest app -q
+git add app/actions/handlers.py app/actions/tests/test_handlers.py
+git commit -m "feat: abandoned reverse backfill records reached coverage floor"
+```
+
+---
+
+### Task 3: Verify, docs, deliver
+
+**Files:**
+- Modify: `README.md` (backfill bullet — recent-first)
+- Modify: `docs/superpowers/specs/2026-07-23-backfill-recent-first-design.md` (status)
+
+**Interfaces:** none — verification and delivery.
+
+- [ ] **Step 1: Clean-build full suite**
+
+```bash
+docker build -t mb-runner-test --target devimage -f docker/Dockerfile .
+docker run --rm mb-runner-test python -m pytest app -q
+```
+Expected: PASS (no volume mount).
+
+- [ ] **Step 2: Discovery check**
+
+```bash
+docker run --rm mb-runner-test python -c "
+from app.actions import action_handlers
+print('actions:', sorted(action_handlers.keys()))
+"
+```
+Expected: the five actions listed.
+
+- [ ] **Step 3: Update README**
+
+In `README.md`, update the backfill bullet to note recent-first ordering:
+
+```markdown
+- **backfill** (executable) — operator-triggered historical load for a study,
+  processed **newest-first**: recent history reaches EarthRanger before older
+  data. Each cascade step processes bounded windows descending from
+  `coverage_start` toward `start`; progress is durable per window, so an
+  interrupted job resumes with no rework. Config: `study_id`, optional
+  `individual_ids`, `start` (a date or `"all"`), optional
+  `backfill_max_concurrency`, `restart`.
+```
+
+(Adapt to fit the current bullet's wording; note any adaptation in the report.)
+
+- [ ] **Step 4: Spec status + commit + push + PR**
+
+```bash
+sed -i '' 's/^\*\*Status:\*\* approved design, pre-implementation/**Status:** implemented/' docs/superpowers/specs/2026-07-23-backfill-recent-first-design.md
+git add README.md docs/superpowers/specs/2026-07-23-backfill-recent-first-design.md
+git commit -m "docs: document recent-first backfill"
+git push -u origin movebank-backfill-recent-first
+gh pr create --base main --head movebank-backfill-recent-first \
+  --title "Recent-first (reverse-chronological) backfill" \
+  --body "Processes a study backfill newest-window-first so recent history reaches ER first. Replaces the event-id dedup floor with timestamp-range ownership. See docs/superpowers/specs/2026-07-23-backfill-recent-first-design.md."
+```
+
+- [ ] **Step 5: Confirm CI green**
+
+Watch the CI run for the pushed commit; expected: success.
+
+---
+
+## Notes for the implementer
+
+- The single biggest effort is Step 6 of Task 1 (reconciling existing forward tests). Work through the failures one at a time; most need only swapping a fixed-timestamp generator for `make_windowed_events_generator` and/or flipping a forward-position assertion to the descending cursor. Preserve each test's original intent.
+- `make_windowed_events_generator`, `INDIVIDUAL_ROW`, `IndividualState`, `BackfillEventsForIndividualConfig` are (or become) available in `test_handlers.py`.
+- Do NOT change `_advance_watermarks`, `_query_start_for_sensor`, `_compute_batch_window`, the steady-state pull, or `coverage_start`'s storage. The reverse loop passes `minimum_event_id=0` and does not call `_query_start_for_sensor`.
+- Keep whole-window atomicity: a window is fully sent or fully discarded; watermarks/`scan_from` never advance on a discarded window.

--- a/docs/superpowers/specs/2026-07-23-backfill-recent-first-design.md
+++ b/docs/superpowers/specs/2026-07-23-backfill-recent-first-design.md
@@ -1,6 +1,6 @@
 # Recent-First (Reverse-Chronological) Backfill — Design
 
-**Status:** approved design, pre-implementation
+**Status:** implemented
 **Date:** 2026-07-23
 **Branch:** movebank-backfill-recent-first (off main, post-PR #17)
 

--- a/docs/superpowers/specs/2026-07-23-backfill-recent-first-design.md
+++ b/docs/superpowers/specs/2026-07-23-backfill-recent-first-design.md
@@ -1,0 +1,188 @@
+# Recent-First (Reverse-Chronological) Backfill — Design
+
+**Status:** approved design, pre-implementation
+**Date:** 2026-07-23
+**Branch:** movebank-backfill-recent-first (off main, post-PR #17)
+
+## Problem / goal
+
+A study backfill can span years. Today `action_backfill_events_for_individual`
+marches a scan position **up** from `start` toward `coverage_start`, so the
+oldest data lands in EarthRanger first and the most recent (operationally most
+valuable) history only appears once the whole multi-day job finishes.
+
+Goal: deliver **recent data first** — process the range `[start, coverage_start)`
+newest-window-first — so ER gains progressively older history from the present
+backward, and a partial run is immediately useful.
+
+## Chosen approach (from brainstorming)
+
+**Full reverse chronological** (not a recent-slice-then-forward hybrid, and not a
+configurable direction): reverse **replaces** forward as the only backfill
+ordering. Recent-first is strictly better operationally once de-duplication is
+handled, and a direction switch would double the surface of a fragile path
+(YAGNI).
+
+## How it works
+
+### Traversal — walk the window down
+
+Today the loop anchors on an ascending scan floor (`current`, advanced
+`current += window`, persisted as `scan_from`). Reverse it:
+
+- Start the position at `end` (= `action_config.end`, i.e. `coverage_start`).
+- Each step processes the window `[max(start, pos − window), pos)`, then sets
+  `pos` to that window's **lower** edge.
+- Continue until `pos <= action_config.start`.
+
+The persisted position (the backfill watermark's `scan_from`, reinterpreted as
+"we have covered `[scan_from, end)`; still owe `[start, scan_from)`") is written
+**every window**, exactly as today — so recent-first progress is durable and a
+re-trigger of the same `job_id` resumes from where it stopped with **zero
+redo**. The step budget, discard/shrink, cascade (`continue` → `trigger_action`),
+and `CancelledError` backstop all carry over unchanged; only the direction of
+`pos` movement and the window bounds flip.
+
+### De-duplication — timestamp-range ownership (replaces the event-id floor)
+
+The forward model dedups via a per-sensor `minimum_event_id` floor that only
+ever marches **up**; reverse breaks it (older windows carry lower ids and would
+be filtered out wholesale). That floor's only real job was cleaning up two
+sources of query over-fetch. In reverse we replace it with **exact
+timestamp-range ownership**:
+
+- Every window fetches its sensors, then the handler **keeps only events whose
+  parsed timestamp is in `[window_lower, window_upper)`** (half-open), discarding
+  the rest. Each event therefore belongs to exactly one window — no cross-window
+  event-id bookkeeping needed.
+- This absorbs both over-fetch sources without special-casing: the
+  movebank-client always prepends 60 min to accessory queries
+  (`movebank_client/client.py:259`) and truncates the query `timestamp_end` to
+  whole seconds (`:254`). Both would otherwise re-deliver rows into adjacent
+  windows; the timestamp filter makes ownership exact at full millisecond
+  precision and **does not depend on Movebank's endpoint inclusivity**.
+- Backfill only ever touches **settled** historical data (`coverage_start ≈
+  now − maximum_lookback_hours`, and every backfill window is below that, older
+  than the 12 h `ACCESSORY_SETTLING_HOURS` margin), so dropping the accessory
+  settling re-read loses nothing: there is no late-arriving accessory data in
+  the historical range. Late arrivals at the *newest* edge remain the
+  steady-state pull's job, unchanged.
+- Consequence: the sub-action passes `minimum_event_id = 0` (no client-side id
+  filter) and no longer calls `_query_start_for_sensor` for the accessory
+  widening. Per-sensor `highest_event_id` / `latest_timestamp` are still tracked
+  from the **kept** events, but only to seed the finalize forward-merge (below),
+  not for dedup. `_query_start_for_sensor` stays in the tree for the
+  steady-state pull, which still needs it.
+
+The per-window overflow cap and the per-step backstop (from the step-budget
+fix) now count **kept** (in-range) events, not raw fetched rows — the cap bounds
+the *send* loop, and the discarded over-fetch (accessory pre-roll, boundary
+second) is never sent. The discard/shrink still triggers on the kept count
+exceeding `MAX_RECORDS_PER_BACKFILL_WINDOW`.
+
+The half-open `[lower, upper)` convention keeps the seam with the pull exact:
+backfill's top window is `[coverage_start − window, coverage_start)`, the pull
+owns `[coverage_start, ∞)`, and an event exactly at `coverage_start` belongs to
+the pull — identical to today's boundary.
+
+### `coverage_start` — progressive progress, race-safe reconciliation
+
+Two distinct records, deliberately kept separate to avoid a concurrency hazard:
+
+1. **Durable progress (per window):** the backfill watermark's descending
+   position, persisted every window (as today). This is the authoritative
+   record that makes recent-first resumable with no redo. It is backfill-owned
+   state (`backfill_watermark` key) — the `*/10` pull never touches it, so there
+   is **no race**.
+
+2. **Pull-facing `coverage_start` (per individual boundary):** the
+   `coverage_start` field lives inside the pull cursor `IndividualState`, which
+   the steady-state pull also writes. Backfill reconciles it at
+   **finalize**, not per window:
+   - **Success** (individual fully backfilled): `coverage_start = start`
+     (unchanged from today).
+   - **Abandon** (max attempts): **new** — set `coverage_start` to the reached
+     floor (the watermark position), via the same forward-merge write finalize
+     already uses for success, so an abandoned reverse job records how far back
+     it actually got. Today's abandon path leaves the pull cursor untouched;
+     this adds a single write on that path.
+
+   **Why not write `coverage_start` every window?** It shares the pull cursor
+   object with the `*/10` pull. Every backfill write to that key is a
+   get-merge-set that can clobber a concurrent pull cursor advance (a known,
+   accepted TOCTOU that finalize incurs **once** per individual today). Writing
+   it per window over a days-long single-individual backfill would multiply that
+   into thousands of chances to revert a pull advance → duplicate observations
+   (`loaded_at` defeats Gundi dedup). The user-facing goal — recent data fast,
+   and a re-run that never redoes completed windows — is fully delivered by
+   reverse traversal + the per-window watermark; `coverage_start` is the
+   coarser pull-facing floor and only needs to be right at individual
+   completion/abandonment.
+
+   **Deferred alternative (out of scope):** if a continuously-moving pull-facing
+   floor is later wanted (e.g. a live progress readout), the race-free way is to
+   store `coverage_start` in its own Redis key decoupled from the sensor cursor,
+   so backfill and the pull never write the same object. Noted, not built —
+   it churns the just-merged `coverage_start` feature for marginal benefit.
+
+### Pull interaction & finalize
+
+Unchanged in substance (see the reverse-backfill/pull analysis): pull and
+backfill run on separate state during the run; the pull owns
+`[coverage_start, ∞)` and never reads `coverage_start` to decide what to fetch;
+`BACKFILL_MAX_CONCURRENCY` (8) keeps backfill below the 25-connection budget so
+the pull isn't starved. Finalize's forward-merge is effectively **inert** in
+reverse (backfill's max timestamp/event-id, captured in the first/recent window,
+sits below `coverage_start`, so `max(pull, backfill)` = the pull's value) — its
+real jobs in reverse are setting `coverage_start` and cleaning up the watermark.
+The `_seed_pull_cursor_at_end` boundary claim at job start is unchanged.
+
+## What changes / what doesn't
+
+- **Changes:** `action_backfill_events_for_individual` window loop (descending
+  traversal; timestamp-range keep-filter; `minimum_event_id=0`; no accessory
+  widening; per-window descending position persist); `_finalize_backfill_individual`
+  abandon path (set `coverage_start` to reached floor).
+- **Unchanged:** step budget + discard/shrink + `window_seconds`; `CancelledError`
+  backstop; `restart` flag; `_seed_pull_cursor_at_end`; the steady-state pull
+  (including its use of `_query_start_for_sensor` and `minimum_event_id`);
+  `_compute_batch_window`; `coverage_start`'s storage (stays an `IndividualState`
+  field); `BackfillConfig` (no new fields).
+
+## Testing
+
+Docker `mb-runner-test`, `respx`/mocked Redis, existing `app/actions/tests`
+patterns.
+
+- Reverse traversal covers `[start, coverage_start)` newest-window-first and
+  reaches `start`; the descending position is persisted every window and a
+  re-trigger resumes from it with no redo.
+- Timestamp-range ownership: an event is emitted by exactly the window whose
+  `[lower, upper)` contains its timestamp; the accessory 60-min client pre-roll
+  and the whole-second `timestamp_end` truncation do **not** cause duplicates or
+  gaps at window seams (assert with events straddling a boundary second and
+  within the accessory pre-roll).
+- The most-recent window is processed first (recent data reaches Gundi before
+  older data).
+- `coverage_start`: success finalize sets it to `start`; abandon finalize sets
+  it to the reached floor; it is **not** written per window (assert the pull
+  cursor is untouched mid-run).
+- Boundary with the pull stays exact (no double-emit at `coverage_start`).
+- Regression: step budget / discard-shrink, `restart`, `CancelledError`, and the
+  steady-state pull tests stay green.
+
+## Files
+
+- `app/actions/handlers.py` — `action_backfill_events_for_individual` (reverse
+  loop + timestamp-range keep-filter + no accessory widening + descending
+  position); `_finalize_backfill_individual` (abandon-path `coverage_start`).
+- `app/actions/tests/*` — coverage per above.
+
+## Out of scope
+
+- Configurable forward/reverse direction (reverse replaces forward).
+- Decoupling `coverage_start` into its own Redis key for per-window pull-facing
+  updates (deferred; the watermark already provides per-window durability).
+- Any movebank-client change (the handler-side timestamp filter absorbs the
+  client's accessory pre-roll and second-truncation).
+- Changing the PubSub ack/redelivery model.


### PR DESCRIPTION
## What

Backfill now processes a study's history **newest-window-first**, so recent tracks reach EarthRanger before older data (a multi-year backfill is useful immediately instead of only after it finishes marching from years ago). Reverse **replaces** forward as the only ordering.

## How (design: `docs/superpowers/specs/2026-07-23-backfill-recent-first-design.md`)

- **Reverse traversal.** A `cursor` descends from `end` (= `coverage_start`) to `start`, processing `[max(start, cursor − window), cursor)` and persisting the descending position every window — so progress is durable and a re-trigger resumes with zero redo.
- **Timestamp-range ownership** replaces the per-sensor `event_id` dedup floor (which only marched up and would filter out older reverse windows). Each window keeps only events with `lower ≤ ts < upper` (half-open), which cleanly absorbs the client's 60-min accessory pre-roll and whole-second `timestamp_end` truncation, with no dependency on Movebank endpoint inclusivity. Backfill only touches settled historical data, so the accessory settling re-read is dropped there.
- **Whole-window atomicity.** An over-cap window is discarded+shrunk+retried; a deadline-**interrupted** window is discarded whole (never partially sent) — without the event-id floor, a partial-send-then-retry would have duplicated events.
- **`coverage_start`.** Durable per-window progress lives in the backfill watermark; the pull-facing `coverage_start` reconciles only at finalize (success → `start`; abandon → reached floor), never per window, to avoid a per-window race with the `*/10` pull.

## Testing

TDD per part; clean Docker build **190 passed**. New tests: recent-window-first ordering, boundary/over-fetch timestamp ownership, descending resume, interrupted-window no-dup on retry, abandon lowers `coverage_start`, and reverse finalize carries the recent window's event-id forward. A whole-branch review caught two issues that were fixed on this branch: the interrupted-window duplicate (discard-whole) and the reverse finalize carrying the oldest (not recent) event-id into the pull cursor (`_advance_watermarks` made cumulative-max so the pull's accessory settling seam still dedups correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)