### PR TITLE
Record action timeouts as warnings, not connection failures

### DIFF
--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -101,6 +101,31 @@ async def _handle_error(
     )
 
 
+async def _handle_recoverable_timeout(exc, integration_id, action_id, config_data=None):
+    """Record an action execution timeout as a WARNING rather than a failure.
+
+    A TimeoutError means the action exceeded MAX_ACTION_EXECUTION_TIME — a
+    workload/duration limit, not a connection (credential/connectivity) problem,
+    and the work is recoverable (cascade actions resume from their persisted
+    progress; a scheduled action simply runs again next tick). So we publish a
+    WARNING custom activity log for visibility instead of an
+    IntegrationActionFailed event, keeping the platform health calculator from
+    marking the connection unhealthy for a recoverable timeout. The full
+    traceback is still logged locally for debugging.
+    """
+    message = f"Action '{action_id}' for integration '{integration_id}' timed out: {exc}"
+    logger.warning(message, exc_info=True)
+    await log_action_activity(
+        integration_id=integration_id,
+        action_id=action_id,
+        title=f"Action '{action_id}' timed out; recorded as a warning (recoverable).",
+        level=LogLevel.WARNING,
+        config_data=config_data or {},
+        data={"error": str(exc)},
+    )
+    return {"timed_out": True, "recoverable": True, "action_id": action_id}
+
+
 def _skip_quietly(integration_id, action_id, *, reason, message, log_level=logging.INFO):
     """Record an expected pull-action skip in the local log only.
 
@@ -268,11 +293,13 @@ async def execute_action(
             timeout=settings.MAX_ACTION_EXECUTION_TIME
         )
     except asyncio.TimeoutError:
-        return await _handle_error(
+        # A timeout is a recoverable workload/duration limit, not a connection
+        # failure — record it as a WARNING so it doesn't mark the connection
+        # unhealthy (see _handle_recoverable_timeout).
+        return await _handle_recoverable_timeout(
             asyncio.TimeoutError(f"Action '{action_id}' timed out"),
             integration_id, action_id,
             config_data={"configurations": [c.dict() for c in integration.configurations]},
-            status_code=status.HTTP_504_GATEWAY_TIMEOUT
         )
     except Exception as e:
         return await _handle_error(e, integration_id, action_id,

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -110,18 +110,23 @@ async def _handle_recoverable_timeout(exc, integration_id, action_id, config_dat
     progress; a scheduled action simply runs again next tick). So we publish a
     WARNING custom activity log for visibility instead of an
     IntegrationActionFailed event, keeping the platform health calculator from
-    marking the connection unhealthy for a recoverable timeout. The full
-    traceback is still logged locally for debugging.
+    marking the connection unhealthy for a recoverable timeout. The traceback is
+    still logged locally for debugging.
+
+    `exc` must be the actual caught TimeoutError; its traceback is logged
+    explicitly via exc_info=exc so the log doesn't depend on an ambient
+    exception context (deterministic even if this helper is ever called outside
+    the originating `except`).
     """
-    message = f"Action '{action_id}' for integration '{integration_id}' timed out: {exc}"
-    logger.warning(message, exc_info=True)
+    message = f"Action '{action_id}' for integration '{integration_id}' timed out (exceeded execution budget)"
+    logger.warning(message, exc_info=exc)
     await log_action_activity(
         integration_id=integration_id,
         action_id=action_id,
         title=f"Action '{action_id}' timed out; recorded as a warning (recoverable).",
         level=LogLevel.WARNING,
         config_data=config_data or {},
-        data={"error": str(exc)},
+        data={"reason": "execution_timeout", "message": message},
     )
     return {"timed_out": True, "recoverable": True, "action_id": action_id}
 
@@ -292,13 +297,13 @@ async def execute_action(
             handler(**handler_kwargs),
             timeout=settings.MAX_ACTION_EXECUTION_TIME
         )
-    except asyncio.TimeoutError:
+    except asyncio.TimeoutError as exc:
         # A timeout is a recoverable workload/duration limit, not a connection
         # failure — record it as a WARNING so it doesn't mark the connection
-        # unhealthy (see _handle_recoverable_timeout).
+        # unhealthy (see _handle_recoverable_timeout). Pass the actual caught
+        # exception so its traceback is logged deterministically.
         return await _handle_recoverable_timeout(
-            asyncio.TimeoutError(f"Action '{action_id}' timed out"),
-            integration_id, action_id,
+            exc, integration_id, action_id,
             config_data={"configurations": [c.dict() for c in integration.configurations]},
         )
     except Exception as e:

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -616,6 +616,12 @@ async def test_execute_action_timeout_logs_warning_not_failure(
         json={"integration_id": str(integration_v2.id), "action_id": "pull_observations"},
     )
 
+    # API contract: a timeout is a recoverable outcome, returned as HTTP 200 with
+    # a {timed_out, recoverable} body — NOT a 504 / error payload.
+    assert response.status_code == 200
+    body = response.json()
+    assert body.get("timed_out") is True
+    assert body.get("recoverable") is True
     # No health-dinging failure event was published.
     assert not _published_events_of_type(mock_publish_event, IntegrationActionFailed)
     # A WARNING-level custom activity log WAS published for visibility.

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import json
 
@@ -589,4 +590,36 @@ async def test_execute_action_with_handler_error(
     assert event.payload.request_data == str(expected_error.request.content or expected_error.request.body)
     assert event.payload.server_response_status == expected_error.response.status_code
     assert event.payload.server_response_body == str(expected_error.response.text)
+
+
+@pytest.mark.asyncio
+async def test_execute_action_timeout_logs_warning_not_failure(
+        mocker, mock_gundi_client_v2, integration_v2, mock_config_manager,
+        mock_publish_event, mock_action_handlers,
+):
+    # A hard execution timeout means the action exceeded its budget — a
+    # workload/duration issue, NOT a connection problem. It must be recorded as
+    # a WARNING custom log, never an IntegrationActionFailed event (which the
+    # platform health calculator would use to mark the connection unhealthy).
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    # Make the handler time out (wait_for propagates asyncio.TimeoutError, hitting
+    # the same except-branch a real MAX_ACTION_EXECUTION_TIME timeout would).
+    handler, _, _ = mock_action_handlers["pull_observations"]
+    handler.side_effect = asyncio.TimeoutError()
+
+    response = api_client.post(
+        "/v1/actions/execute/",
+        json={"integration_id": str(integration_v2.id), "action_id": "pull_observations"},
+    )
+
+    # No health-dinging failure event was published.
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+    # A WARNING-level custom activity log WAS published for visibility.
+    warnings = _published_events_of_type(mock_publish_event, IntegrationActionCustomLog)
+    assert warnings, "expected a custom activity log for the timeout"
+    assert any(w.payload.level == LogLevel.WARNING for w in warnings)
 


### PR DESCRIPTION
## What

An action execution `TimeoutError` (from `asyncio.wait_for(handler, MAX_ACTION_EXECUTION_TIME)` in `execute_action`) was routed through `_handle_error`, which publishes an `IntegrationActionFailed` event — the signal the Gundi platform's health calculator uses to mark a connection **unhealthy**. But a timeout is a workload/duration limit (recoverable — cascade actions resume from persisted progress; scheduled actions run again next tick), **not** a connection (credential/connectivity) problem.

## How

`execute_action`'s `except asyncio.TimeoutError` now calls a new `_handle_recoverable_timeout`, which publishes a **WARNING** custom activity log (`log_action_activity(..., level=LogLevel.WARNING)` → `IntegrationActionCustomLog`) instead of `IntegrationActionFailed`. So the timeout is still visible in the portal feed but no longer marks the connection unhealthy. Local traceback logging (`logger.warning(..., exc_info=True)`) is preserved. Applies to all action timeouts. The generic `except Exception` path (real errors) is unchanged and still publishes the failure event.

Note: a timed-out synchronous `/v1/actions/execute` call now returns a 200 `{"timed_out": true, "recoverable": true, ...}` body instead of a 504 — consistent with the codebase's skip-returns-200-dict convention; the PubSub entry points ack regardless and the health signal is the event, not the HTTP status.

## Scope

Touches `app/services/action_runner.py`, which is shared with the upstream `gundi-integration-action-runner` template — worth upstreaming.

## Testing

TDD: new `test_execute_action_timeout_logs_warning_not_failure` asserts no `IntegrationActionFailed` and a WARNING `IntegrationActionCustomLog` on timeout (fails pre-change: old code emitted the failure event + 504). Full suite 186 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)