### PR TITLE
Fix: pull up to now, not Movebank's stale timestamp_end

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -245,7 +245,12 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
     now = datetime.now(tz=timezone.utc)
     # Some individuals don't provide timestamp_end, so resolve a reasonable value.
     resolved_individual_timestamp_end = ind.timestamp_end or now
-    highest_date = min(now, resolved_individual_timestamp_end)
+    # Fetch up to NOW, NOT the individual's timestamp_end. Movebank's per-individual
+    # timestamp_end is derived study metadata that often lags the live event
+    # stream, so capping here froze collection once a cursor caught up to a stale
+    # value ("no new data" forever). The per-sensor cursor + event-id filter dedup,
+    # and the empty-window quiet flag idles genuinely dormant individuals.
+    highest_date = now
 
     sensor_type_ids = _supported_sensor_type_ids(ind)
     if not sensor_type_ids:
@@ -264,8 +269,11 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
             individual_id=ind.id, study_id=action_config.study_id, local_identifier=ind.local_identifier
         )
 
-    # Build per-sensor cursors from state; new sensors start at the lookback window.
-    default_start = resolved_individual_timestamp_end - timedelta(hours=action_config.maximum_lookback_hours)
+    # Build per-sensor cursors from state; new sensors start at the lookback
+    # window measured from NOW (not timestamp_end, which can be stale) so a fresh
+    # individual's first run stays bounded to the recent window — history is the
+    # backfill's job.
+    default_start = now - timedelta(hours=action_config.maximum_lookback_hours)
     if was_fresh:
         # First-ever cursor for this individual: record the oldest point the pull
         # will cover, so a later backfill knows where to stop (fills [start, this)).
@@ -278,7 +286,10 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
         minimum_event_ids[sensor_type_id] = (sensor_state.highest_event_id or 0) + 1
 
     earliest_start = min(sensor_type_timestamps.values())
-    if earliest_start >= resolved_individual_timestamp_end:
+    if earliest_start >= now:
+        # Cursor has reached the present — nothing to fetch. (Idle individuals
+        # whose cursor is behind `now` are handled by the empty-window quiet
+        # flag below, not by the stale timestamp_end metadata.)
         logger.info(f"Skip Movebank {log_reference} for no new data.")
         return {"skipped": "no_new_data"}
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -243,8 +243,6 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
         return {"skipped": "no_timestamp_start"}
 
     now = datetime.now(tz=timezone.utc)
-    # Some individuals don't provide timestamp_end, so resolve a reasonable value.
-    resolved_individual_timestamp_end = ind.timestamp_end or now
     # Fetch up to NOW, NOT the individual's timestamp_end. Movebank's per-individual
     # timestamp_end is derived study metadata that often lags the live event
     # stream, so capping here froze collection once a cursor caught up to a stale
@@ -296,10 +294,10 @@ async def action_pull_events_for_individual(integration, action_config: PullEven
     # Size the fetch window by event density (shared with backfill via
     # _compute_batch_window): high-frequency individuals get a window that
     # should hold roughly HIGH_FREQUENCY_INDIVIDUAL_THRESHOLD events, assuming
-    # an even distribution over the individual's active range.
-    # resolved_individual_timestamp_end falls back to now when the individual
-    # omits timestamp_end, so density sizing works for those individuals too.
-    total_seconds = (resolved_individual_timestamp_end - ind.timestamp_start).total_seconds()
+    # an even distribution over the individual's active range. Size against `now`,
+    # not timestamp_end: a stale timestamp_end would shrink the span and produce
+    # needlessly small windows (extra Movebank calls) for high-frequency tags.
+    total_seconds = (now - ind.timestamp_start).total_seconds()
     batch_window_size = _compute_batch_window(ind.number_of_events, total_seconds)
 
     logger.info(

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -357,20 +357,31 @@ async def test_pull_events_respects_max_records_cap(
     assert calls["count"] == 2  # third window never ran
 
 
+def test_compute_batch_window_falls_back_on_nonpositive_span():
+    from app.actions.handlers import _compute_batch_window, DEFAULT_BATCH_WINDOW
+    # A non-positive span (e.g. timestamp_start >= now) would give a
+    # non-positive, never-advancing window for a high-frequency individual — the
+    # guard must fall back to the default.
+    assert _compute_batch_window(6000, 0) == DEFAULT_BATCH_WINDOW
+    assert _compute_batch_window(6000, -100) == DEFAULT_BATCH_WINDOW
+    # A positive span for a high-frequency individual yields a smaller window.
+    assert _compute_batch_window(10000, 5 * 86400) < DEFAULT_BATCH_WINDOW
+    # Low-frequency individuals always get the default window.
+    assert _compute_batch_window(100, 5 * 86400) == DEFAULT_BATCH_WINDOW
+
+
 @pytest.mark.asyncio
-async def test_pull_events_zero_range_high_frequency_individual_terminates(
+async def test_pull_events_high_frequency_individual_no_events_terminates(
         mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
 ):
-    # timestamp_end == timestamp_start would make the density window zero -> guard must fall back.
+    # A high-frequency individual (density-sized window) with no new events must
+    # terminate cleanly rather than spin. (The zero-span window guard itself is
+    # covered by test_compute_batch_window_falls_back_on_nonpositive_span.)
     mock_movebank_client.get_individual_events_by_time = make_events_generator([])
     mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
     result = await action_pull_events_for_individual(
         integration=integration,
-        action_config=_sub_action_config(individual_overrides={
-            "number_of_events": "6000",
-            "timestamp_start": "2026-07-01 00:00:00.000",
-            "timestamp_end": "2026-07-01 00:00:00.000",
-        }),
+        action_config=_sub_action_config(individual_overrides={"number_of_events": "6000"}),
     )
     assert result["observations_sent"] == 0
 

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -175,8 +175,9 @@ async def test_pull_events_skips_when_caught_up_to_present(
     # "no new data" is gated on NOW, not the individual's timestamp_end: only a
     # cursor that has reached the present skips. (A cursor merely at a stale
     # timestamp_end must NOT skip — see test_pull_events_fetches_beyond_stale_...)
+    # Cursor is relative to now (an hour ahead) so the test is time-independent.
     state = IndividualState(individual_id="111", study_id="12345")
-    state.update_sensor_state(653, datetime(2099, 1, 1, tzinfo=timezone.utc), 999)
+    state.update_sensor_state(653, datetime.now(timezone.utc) + timedelta(hours=1), 999)
     mock_state_store[(str(integration.id), "pull_events_for_individual", "111")] = state.dict()
 
     result = await action_pull_events_for_individual(

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -169,18 +169,90 @@ async def test_pull_events_skips_individual_without_timestamp_start(
 
 
 @pytest.mark.asyncio
-async def test_pull_events_skips_when_all_sensors_are_current(
+async def test_pull_events_skips_when_caught_up_to_present(
         mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
 ):
-    # Saved cursor is already past the individual's timestamp_end.
+    # "no new data" is gated on NOW, not the individual's timestamp_end: only a
+    # cursor that has reached the present skips. (A cursor merely at a stale
+    # timestamp_end must NOT skip — see test_pull_events_fetches_beyond_stale_...)
     state = IndividualState(individual_id="111", study_id="12345")
-    state.update_sensor_state(653, datetime(2026, 7, 1, tzinfo=timezone.utc), 999)
+    state.update_sensor_state(653, datetime(2099, 1, 1, tzinfo=timezone.utc), 999)
     mock_state_store[(str(integration.id), "pull_events_for_individual", "111")] = state.dict()
 
     result = await action_pull_events_for_individual(
         integration=integration, action_config=_sub_action_config()
     )
     assert result == {"skipped": "no_new_data"}
+
+
+@pytest.mark.asyncio
+async def test_pull_events_fetches_beyond_stale_timestamp_end(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # Regression: Movebank's per-individual timestamp_end metadata lags the live
+    # feed. A cursor caught up to a stale timestamp_end (INDIVIDUAL_ROW's is
+    # 2026-07-01, before `now`) must NOT freeze the pull — events after it and
+    # before now must still be fetched.
+    state = IndividualState(individual_id="111", study_id="12345")
+    state.update_sensor_state(653, datetime(2026, 7, 1, tzinfo=timezone.utc), 999)
+    mock_state_store[(str(integration.id), "pull_events_for_individual", "111")] = state.dict()
+    events = [_gps_event(1000, "2026-07-10 00:00:00.000"), _gps_event(1001, "2026-07-11 00:00:00.000")]
+
+    def gen(**kwargs):
+        # Mirror the real client's event-id filter so an advanced cursor doesn't
+        # re-yield already-sent events on later windows.
+        min_id = kwargs.get("minimum_event_id", 0)
+        async def _agen():
+            for e in events:
+                if int(e["event_id"]) >= min_id:
+                    yield e
+        return _agen()
+    mock_movebank_client.get_individual_events_by_time = gen
+    mock_send = mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+
+    result = await action_pull_events_for_individual(
+        integration=integration, action_config=_sub_action_config()
+    )
+
+    assert result.get("observations_sent") == 2
+    assert mock_send.await_count >= 1
+    saved = mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
+    assert IndividualState.parse_obj(saved).get_sensor_state(653).highest_event_id == 1001
+
+
+@pytest.mark.asyncio
+async def test_pull_events_fetch_window_extends_past_timestamp_end(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    # Isolates the highest_date=now fix (independent of the no-new-data gate):
+    # cursor is BEFORE the stale timestamp_end, so the gate never fires either
+    # way; events dated AFTER timestamp_end are only reachable if the fetch
+    # window extends to `now`. Uses a range-respecting generator (like Movebank's
+    # time-bounded API), so a `min(now, timestamp_end)` cap would never see them.
+    state = IndividualState(individual_id="111", study_id="12345")
+    state.update_sensor_state(653, datetime(2026, 6, 25, tzinfo=timezone.utc), 500)
+    mock_state_store[(str(integration.id), "pull_events_for_individual", "111")] = state.dict()
+    # timestamp_end = 2026-07-01 (INDIVIDUAL_ROW default); events are after it.
+    events = [_gps_event(1000, "2026-07-10 00:00:00.000"), _gps_event(1001, "2026-07-12 00:00:00.000")]
+
+    def gen(**kwargs):
+        q_start, q_end = kwargs["timestamp_start"], kwargs["timestamp_end"]
+        min_id = kwargs.get("minimum_event_id", 0)
+        async def _agen():
+            for e in events:
+                ts = datetime.strptime(e["timestamp"], "%Y-%m-%d %H:%M:%S.%f").replace(tzinfo=timezone.utc)
+                if int(e["event_id"]) >= min_id and q_start <= ts < q_end:
+                    yield e
+        return _agen()
+    mock_movebank_client.get_individual_events_by_time = gen
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+
+    result = await action_pull_events_for_individual(
+        integration=integration, action_config=_sub_action_config()
+    )
+
+    # Reachable only because the window now extends to `now`, not timestamp_end.
+    assert result.get("observations_sent") == 2
 
 
 def make_counting_events_generator(events_per_call):
@@ -1476,23 +1548,23 @@ async def test_dispatch_rolls_back_and_requeues_on_trigger_failure(mocker):
 async def test_pull_first_run_stamps_coverage_start(
         mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
 ):
-    # Fresh individual (no saved cursor): after the first run that persists a
-    # cursor, coverage_start must equal default_start = timestamp_end - lookback.
+    # Fresh individual (no saved cursor): coverage_start is stamped at
+    # default_start = now - lookback (NOT timestamp_end, which can be stale).
     events = [_gps_event(100, "2026-06-30 10:00:00.000")]
     mock_movebank_client.get_individual_events_by_time = make_events_generator(events)
     mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
 
+    before = datetime.now(timezone.utc)
     await action_pull_events_for_individual(
         integration=integration,
-        action_config=_sub_action_config(
-            maximum_lookback_hours=24,
-            individual_overrides={"timestamp_end": "2026-07-01 00:00:00.000"},
-        ),
+        action_config=_sub_action_config(maximum_lookback_hours=24),
     )
+    after = datetime.now(timezone.utc)
 
     saved = mock_state_store[(str(integration.id), "pull_events_for_individual", "111")]
     state = IndividualState.parse_obj(saved)
-    assert state.coverage_start == datetime(2026, 6, 30, 0, 0, tzinfo=timezone.utc)  # end - 24h
+    # Stamped at (a `now` captured during the call) - 24h, so it lands in the window.
+    assert before - timedelta(hours=24) <= state.coverage_start <= after - timedelta(hours=24)
 
 
 @pytest.mark.asyncio

--- a/scripts/verify_movebank_timestamp_end.py
+++ b/scripts/verify_movebank_timestamp_end.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
-"""Verify whether a Movebank study's per-individual `timestamp_end` metadata is
-STALE relative to the actual event stream — the suspected reason the pull skips
-for "no new data".
+"""Diagnostic: detect whether a Movebank study's per-individual `timestamp_end`
+metadata is STALE relative to the actual event stream — i.e. real events exist
+after the reported end.
 
-The steady-state pull caps its fetch at `min(now, individual.timestamp_end)` and
-short-circuits once a sensor cursor reaches `timestamp_end`. If Movebank's
-`timestamp_end` (from the get_individuals_by_study metadata) lags real events,
-new data is never fetched. This script checks, per individual, whether GPS
-events exist STRICTLY AFTER the reported `timestamp_end`.
+This was the root cause of a pull that stopped importing new data: the pull used
+to cap its fetch at `min(now, individual.timestamp_end)` and short-circuit once a
+sensor cursor reached `timestamp_end`, so a stale `timestamp_end` (from the
+get_individuals_by_study metadata) hid all newer events. The pull no longer uses
+`timestamp_end` for its bounds (it fetches up to `now`), so this is now an
+informational check on Movebank metadata quality rather than a live-bug detector.
+It checks, per individual, whether GPS events exist STRICTLY AFTER the reported
+`timestamp_end`.
 
 Read-only: it only issues Movebank direct-read queries; it writes nothing to
 Redis, Gundi, or EarthRanger.

--- a/scripts/verify_movebank_timestamp_end.py
+++ b/scripts/verify_movebank_timestamp_end.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Verify whether a Movebank study's per-individual `timestamp_end` metadata is
+STALE relative to the actual event stream — the suspected reason the pull skips
+for "no new data".
+
+The steady-state pull caps its fetch at `min(now, individual.timestamp_end)` and
+short-circuits once a sensor cursor reaches `timestamp_end`. If Movebank's
+`timestamp_end` (from the get_individuals_by_study metadata) lags real events,
+new data is never fetched. This script checks, per individual, whether GPS
+events exist STRICTLY AFTER the reported `timestamp_end`.
+
+Read-only: it only issues Movebank direct-read queries; it writes nothing to
+Redis, Gundi, or EarthRanger.
+
+Credentials/target come from env (no secrets in the file):
+    MOVEBANK_USERNAME   (required)
+    MOVEBANK_PASSWORD   (required)
+    MOVEBANK_STUDY_ID   (required)
+    MOVEBANK_BASE_URL   (default https://www.movebank.org)
+    MOVEBANK_INDIVIDUAL_ID  (optional — check just this one)
+    MAX_INDIVIDUALS     (optional — cap how many individuals to check)
+
+Run (with network + creds), e.g. inside the test image:
+    docker run --rm -e MOVEBANK_USERNAME -e MOVEBANK_PASSWORD -e MOVEBANK_STUDY_ID \
+      -v "$PWD/app":/code/app -v "$PWD/scripts":/code/scripts -w /code \
+      mb-runner-test python scripts/verify_movebank_timestamp_end.py
+"""
+import asyncio
+import os
+import sys
+from datetime import datetime, timezone
+
+from dateutil.parser import parse as parse_date
+
+# Make `app` importable regardless of CWD: add the repo root (this file's
+# parent-of-parent, e.g. /code when scripts/ is mounted at /code/scripts).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import app.actions.client as client
+from app.actions.client import generate_individuals
+
+
+def _utc(dt):
+    return dt.astimezone(timezone.utc) if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+async def _events_after(mb, study_id, individual_id, after, now):
+    """Count GPS events strictly after `after`, and track the latest timestamp.
+    Mirrors the pull's query (sensor 653), but with minimum_event_id=0 so no
+    cursor filtering hides anything."""
+    count = 0
+    latest = None
+    async for event in mb.get_individual_events_by_time(
+        study_id=study_id, individual_id=individual_id,
+        timestamp_start=after, timestamp_end=now,
+        sensor_type_ids=[client.MovebankClient.SENSOR_TYPE_GPS], minimum_event_id=0,
+    ):
+        try:
+            ts = _utc(parse_date(event.get("timestamp")))
+        except Exception:
+            continue
+        if ts > after:                       # strictly beyond the reported end
+            count += 1
+            if latest is None or ts > latest:
+                latest = ts
+    return count, latest
+
+
+async def main():
+    username = os.environ.get("MOVEBANK_USERNAME")
+    password = os.environ.get("MOVEBANK_PASSWORD")
+    study_id = os.environ.get("MOVEBANK_STUDY_ID")
+    base_url = os.environ.get("MOVEBANK_BASE_URL", "https://www.movebank.org")
+    only_individual = os.environ.get("MOVEBANK_INDIVIDUAL_ID")
+    max_individuals = os.environ.get("MAX_INDIVIDUALS")
+    if not (username and password and study_id):
+        sys.exit("Set MOVEBANK_USERNAME, MOVEBANK_PASSWORD, and MOVEBANK_STUDY_ID.")
+
+    now = datetime.now(tz=timezone.utc)
+    mb_client = client.MovebankClient(base_url=base_url, username=username, password=password)
+
+    stale = 0
+    checked = 0
+    async with mb_client as mb:
+        rows = await mb.get_individuals_by_study(study_id=study_id)
+        individuals = list(generate_individuals(rows))
+        if only_individual:
+            individuals = [i for i in individuals if i.id == only_individual]
+        if max_individuals:
+            individuals = individuals[: int(max_individuals)]
+
+        print(f"Study {study_id}: checking {len(individuals)} individual(s); now={now.isoformat()}\n")
+        for ind in individuals:
+            end = ind.timestamp_end
+            if end is None:
+                print(f"  {ind.id} ({ind.nick_name}): no timestamp_end (pull uses `now` — not affected)")
+                continue
+            end = _utc(end)
+            checked += 1
+            count, latest = await _events_after(mb, study_id, ind.id, end, now)
+            if count > 0:
+                stale += 1
+                lag = latest - end
+                print(f"  STALE  {ind.id} ({ind.nick_name}): timestamp_end={end.isoformat()} "
+                      f"but {count} GPS event(s) after it; latest={latest.isoformat()} (lag {lag})")
+            else:
+                print(f"  ok     {ind.id} ({ind.nick_name}): timestamp_end={end.isoformat()}, "
+                      f"no GPS events after it")
+
+    print(f"\nSummary: {stale}/{checked} individual(s) with real GPS events beyond their "
+          f"reported timestamp_end.")
+    if stale:
+        print("=> CONFIRMED: timestamp_end metadata is stale; the pull's timestamp_end ceiling "
+              "is hiding new data.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Problem

New Movebank data stopped importing for a study: individuals were logging **"Skip … for no new data"** every `*/10` tick despite fresh points in the portal. Root cause (confirmed against the live study): the steady-state pull bounded its fetch by the individual's **`timestamp_end`** metadata from `get_individuals_by_study`. That field is derived study metadata that **lags the live event stream**, so once a per-sensor cursor caught up to a stale `timestamp_end`, the pull:
- short-circuited at `if earliest_start >= timestamp_end: return "no_new_data"`, and
- never queried past `highest_date = min(now, timestamp_end)`,

so every event after the stale `timestamp_end` was invisible — permanently.

Verified with `scripts/verify_movebank_timestamp_end.py` (added here): affected individuals had real GPS events well after their reported `timestamp_end`.

## Fix

Stop trusting `timestamp_end` for the pull's bounds — fetch up to `now`:
- `highest_date = now` (was `min(now, timestamp_end)`).
- No-new-data gate is `earliest_start >= now` (was `>= timestamp_end`) — a cursor merely at a stale `timestamp_end` proceeds to fetch.
- First-run `default_start = now − lookback` (was `timestamp_end − lookback`), so a fresh individual starts bounded/recent and `coverage_start` is stamped there.

The per-sensor cursor + `event_id` filter still dedup (re-querying `[cursor, now)` each tick doesn't resend), and the empty-window quiet flag still idles genuinely dormant individuals — now based on real empty fetches rather than stale metadata. The backfill/pull `coverage_start` boundary is preserved (no overlap).

## Tests

- `fetches_beyond_stale_timestamp_end` — cursor at a stale `timestamp_end`; asserts events after it are fetched (RED pre-fix: returned `no_new_data`).
- `fetch_window_extends_past_timestamp_end` — cursor *before* the stale end with a **range-respecting** generator; isolates the `highest_date=now` fix (a `min(now, timestamp_end)` cap would never reach the events).
- `skips_when_caught_up_to_present` and the first-run `coverage_start` test updated to the now-based semantics.

Full suite: **194 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)