### PR TITLE
Treat provider rate limiting as a recoverable WARNING (not a failure)

### DIFF
--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -131,34 +131,61 @@ async def _handle_error(
     )
 
 
-async def _handle_recoverable_timeout(exc, integration_id, action_id, config_data=None):
-    """Record an action execution timeout as a WARNING rather than a failure.
+async def _publish_recoverable_warning(exc, integration_id, action_id, *, title, message, reason, config_data=None):
+    """Record a recoverable, expected condition as a WARNING activity log
+    instead of an IntegrationActionFailed event.
 
-    A TimeoutError means the action exceeded MAX_ACTION_EXECUTION_TIME — a
-    workload/duration limit, not a connection (credential/connectivity) problem,
-    and the work is recoverable (cascade actions resume from their persisted
-    progress; a scheduled action simply runs again next tick). So we publish a
-    WARNING custom activity log for visibility instead of an
-    IntegrationActionFailed event, keeping the platform health calculator from
-    marking the connection unhealthy for a recoverable timeout. The traceback is
-    still logged locally for debugging.
+    Some failures are transient by nature — an execution timeout (the action
+    exceeded MAX_ACTION_EXECUTION_TIME) or provider rate limiting (429 retries
+    exhausted). Neither is a connection (credential/connectivity) problem, and
+    the work resumes on the next run (cascade actions from their persisted
+    progress; a scheduled action on the next tick). Surfacing them as hard
+    failures would let the platform health calculator mark the connection
+    unhealthy for something we expect to recover from, so we publish a WARNING
+    custom activity log for visibility instead.
 
-    `exc` must be the actual caught TimeoutError; its traceback is logged
-    explicitly via exc_info=exc so the log doesn't depend on an ambient
-    exception context (deterministic even if this helper is ever called outside
-    the originating `except`).
+    `exc` must be the actual caught exception; its traceback is logged via
+    exc_info=exc so the log doesn't depend on an ambient exception context
+    (deterministic even if this helper is ever called outside the originating
+    `except`).
     """
-    message = f"Action '{action_id}' for integration '{integration_id}' timed out (exceeded execution budget)"
     logger.warning(message, exc_info=exc)
     await log_action_activity(
         integration_id=integration_id,
         action_id=action_id,
-        title=f"Action '{action_id}' timed out; recorded as a warning (recoverable).",
+        title=title,
         level=LogLevel.WARNING,
         config_data=config_data or {},
-        data={"reason": "execution_timeout", "message": message},
+        data={"reason": reason, "message": message},
+    )
+
+
+async def _handle_recoverable_timeout(exc, integration_id, action_id, config_data=None):
+    """Record an action execution timeout as a WARNING (recoverable). See
+    _publish_recoverable_warning for why this isn't a hard failure."""
+    message = f"Action '{action_id}' for integration '{integration_id}' timed out (exceeded execution budget)"
+    await _publish_recoverable_warning(
+        exc, integration_id, action_id,
+        title=f"Action '{action_id}' timed out; recorded as a warning (recoverable).",
+        message=message,
+        reason="execution_timeout",
+        config_data=config_data,
     )
     return {"timed_out": True, "recoverable": True, "action_id": action_id}
+
+
+async def _handle_recoverable_rate_limit(exc, integration_id, action_id, config_data=None):
+    """Record provider rate limiting (e.g. 429 retries exhausted) as a WARNING
+    (recoverable) rather than a hard failure. See _publish_recoverable_warning."""
+    message = f"Action '{action_id}' for integration '{integration_id}' was rate limited by the provider: {exc}"
+    await _publish_recoverable_warning(
+        exc, integration_id, action_id,
+        title=f"Action '{action_id}' rate limited; recorded as a warning (recoverable).",
+        message=message,
+        reason="rate_limit",
+        config_data=config_data,
+    )
+    return {"rate_limited": True, "recoverable": True, "action_id": action_id}
 
 
 def _skip_quietly(integration_id, action_id, *, reason, message, log_level=logging.INFO):
@@ -337,6 +364,16 @@ async def execute_action(
             config_data={"configurations": [c.dict() for c in integration.configurations]},
         )
     except Exception as e:
+        # Provider rate limiting (e.g. movebank-client raises after exhausting
+        # its 429 retries) is a recoverable, expected condition — the action
+        # runs again on its next tick. Record it as a WARNING instead of an
+        # IntegrationActionFailed so it doesn't mark the connection unhealthy.
+        classified = classify_error(e)
+        if classified is not None and classified.error_type == "rate_limit":
+            return await _handle_recoverable_rate_limit(
+                e, integration_id, action_id,
+                config_data={"configurations": [c.dict() for c in integration.configurations]},
+            )
         return await _handle_error(e, integration_id, action_id,
                                    config_data={"configurations": [c.dict() for c in integration.configurations]},
                                    classify_heuristics=True)

--- a/app/services/action_runner.py
+++ b/app/services/action_runner.py
@@ -144,12 +144,13 @@ async def _publish_recoverable_warning(exc, integration_id, action_id, *, title,
     unhealthy for something we expect to recover from, so we publish a WARNING
     custom activity log for visibility instead.
 
-    `exc` must be the actual caught exception; its traceback is logged via
-    exc_info=exc so the log doesn't depend on an ambient exception context
-    (deterministic even if this helper is ever called outside the originating
-    `except`).
+    `exc` must be the actual caught exception. Its traceback is logged via an
+    explicit (type, value, traceback) tuple built from the exception object
+    itself, so the log takes the traceback from `exc.__traceback__` rather than
+    the ambient `sys.exc_info()` — deterministic even if this helper is ever
+    called outside the originating `except`.
     """
-    logger.warning(message, exc_info=exc)
+    logger.warning(message, exc_info=(type(exc), exc, exc.__traceback__))
     await log_action_activity(
         integration_id=integration_id,
         action_id=action_id,
@@ -177,7 +178,11 @@ async def _handle_recoverable_timeout(exc, integration_id, action_id, config_dat
 async def _handle_recoverable_rate_limit(exc, integration_id, action_id, config_data=None):
     """Record provider rate limiting (e.g. 429 retries exhausted) as a WARNING
     (recoverable) rather than a hard failure. See _publish_recoverable_warning."""
-    message = f"Action '{action_id}' for integration '{integration_id}' was rate limited by the provider: {exc}"
+    # Only the first line of the exception — some (e.g. httpx.HTTPStatusError)
+    # stringify to multi-line text that would make the activity-feed message
+    # noisy. Consistent with classify_error's first-line rendering.
+    detail = (str(exc).splitlines() or [""])[0]
+    message = f"Action '{action_id}' for integration '{integration_id}' was rate limited by the provider: {detail}"
     await _publish_recoverable_warning(
         exc, integration_id, action_id,
         title=f"Action '{action_id}' rate limited; recorded as a warning (recoverable).",

--- a/app/services/tests/test_action_runner.py
+++ b/app/services/tests/test_action_runner.py
@@ -634,6 +634,55 @@ async def test_execute_action_timeout_logs_warning_not_failure(
 
 
 @pytest.mark.asyncio
+async def test_execute_action_rate_limit_logs_warning_not_failure(
+        mocker, mock_gundi_client_v2, integration_v2, mock_config_manager,
+        mock_publish_event, mock_action_handlers,
+):
+    # Provider rate limiting (a 429 whose retries the client exhausted) is a
+    # recoverable, expected condition — the action runs again on its next tick.
+    # It must be recorded as a WARNING custom log, never an
+    # IntegrationActionFailed event (which the platform health calculator would
+    # use to mark the connection unhealthy). In production movebank-client
+    # raises MBRateLimitError carrying the final 429 response; here we raise a
+    # generic exception with the same `.response.status_code == 429` signal so
+    # the runner's classify_error path (429 -> "rate_limit") fires regardless of
+    # the client version installed in the test image.
+    mocker.patch("app.services.action_runner.action_handlers", mock_action_handlers)
+    mocker.patch("app.services.action_runner._portal", mock_gundi_client_v2)
+    mocker.patch("app.services.action_runner.config_manager", mock_config_manager)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    rate_limited = Exception("Rate limit retries exhausted after 3 attempts over 31.0s")
+    rate_limited.response = httpx.Response(
+        429, request=httpx.Request("GET", "https://www.movebank.org/movebank/service/direct-read")
+    )
+    handler, _, _ = mock_action_handlers["pull_observations"]
+    handler.side_effect = rate_limited
+
+    response = api_client.post(
+        "/v1/actions/execute/",
+        json={"integration_id": str(integration_v2.id), "action_id": "pull_observations"},
+    )
+
+    # API contract: rate limiting is a recoverable outcome, returned as HTTP 200
+    # with a {rate_limited, recoverable} body — NOT an error payload.
+    assert response.status_code == 200
+    body = response.json()
+    assert body.get("rate_limited") is True
+    assert body.get("recoverable") is True
+    # No health-dinging failure event was published.
+    assert not _published_events_of_type(mock_publish_event, IntegrationActionFailed)
+    # A WARNING-level custom activity log WAS published for visibility.
+    warnings = _published_events_of_type(mock_publish_event, IntegrationActionCustomLog)
+    assert warnings, "expected a custom activity log for the rate limit"
+    assert any(w.payload.level == LogLevel.WARNING for w in warnings)
+    assert any(
+        (w.payload.data or {}).get("reason") == "rate_limit"
+        for w in warnings
+    )
+
+
+@pytest.mark.asyncio
 async def test_push_data_acks_message_without_destination_id(
         mocker, pubsub_message_request_headers, run_push_action_pubsub_payload
 ):


### PR DESCRIPTION
## Why
When Movebank rate-limit (429) retries are exhausted, the run today surfaces as an `IntegrationActionFailed` event, which the platform health calculator uses to mark the connection **unhealthy**. But this is an *expected, recoverable* condition — the action runs again on its next tick.

Example that motivated this:
> `Error running action 'pull_events_for_individual': Rate limit retries exhausted after 3 attempts over 31.0s`

The goal is to avoid marking a connection unhealthy due only to rate limiting we expect to recover from.

## What
- Route any `rate_limit`-classified error (`classify_error` → a 429 `response` → `"rate_limit"`) to a **WARNING** custom activity log instead of `IntegrationActionFailed`.
- Generalize the existing recoverable-timeout path: extract `_publish_recoverable_warning`, now shared by `_handle_recoverable_timeout` and the new `_handle_recoverable_rate_limit`.

This pairs with **movebank-client 1.3.2** (PADAS/movebank-client#9), where `on_giveup_429` raises a dedicated `MBRateLimitError` carrying the final 429 response so it classifies as `rate_limit`. A follow-up will bump the client dep to `~=1.3.2` once that release is on PyPI.

## Tests
New `test_execute_action_rate_limit_logs_warning_not_failure`: HTTP 200 `{rate_limited, recoverable}`, **no** `IntegrationActionFailed`, a WARNING custom log with `reason="rate_limit"`. The test mocks the 429 signal, so it's green on the current `1.3.1` lock. Full suite: 231 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)