### PR TITLE
chore: bump movebank-client to ~=1.3.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,1 @@
-movebank-client~=1.3.1
+movebank-client~=1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,7 +89,7 @@ marshmallow==3.22.0
     #   -r requirements-base.in
     #   environs
     #   movebank-client
-movebank-client==1.3.1
+movebank-client==1.3.2
     # via -r requirements.in
 multidict==6.0.5
     # via


### PR DESCRIPTION
Follow-up to #22 (merged before this dependency bump). movebank-client 1.3.2 is published; this bumps requirements.in to ~=1.3.2 and recompiles the lock to ==1.3.2. Full suite passes (231) against the real client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)