### PR TITLE
fix: default Movebank base_url to https://www.movebank.org

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Union
 
 import pydantic
 from dateutil.parser import parse as parse_date
-from movebank_client import MovebankClient
+from movebank_client import MovebankClient as _MovebankClient
 # Not used in this module directly — re-exported for consumers that access them
 # through this namespace (e.g. `client.MBForbiddenError` in app/actions/handlers.py).
 from movebank_client.errors import MBClientError, MBForbiddenError
@@ -13,6 +13,18 @@ from app.services.errors import ConfigurationNotFound
 from app.services.utils import find_config_for_action
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_MOVEBANK_BASE_URL = "https://www.movebank.org"
+
+
+class MovebankClient(_MovebankClient):
+    """Defaults base_url to the public Movebank server when the integration
+    record leaves it unset (None or empty string)."""
+
+    def __init__(self, **kwargs):
+        if not kwargs.get("base_url"):
+            kwargs["base_url"] = DEFAULT_MOVEBANK_BASE_URL
+        super().__init__(**kwargs)
 
 
 def get_auth_config(integration):


### PR DESCRIPTION
## Summary

Makes `https://www.movebank.org` the default `base_url` for every `MovebankClient` this integration builds, so an integration whose portal record leaves the base URL blank still talks to the public Movebank server.

## Why

All five client construction sites in `app/actions/handlers.py` (auth, pull_observations, the per-individual pull, backfill, and the backfill loop) pass `base_url=integration.base_url` explicitly. Because the argument is always present, it bypassed the upstream library's own `MOVEBANK_API_BASE_URL` fallback — a blank portal field meant `self.base_url` became `None` and every endpoint was built as `None/movebank/service/...`.

## Approach

Rather than repeat a default at five call sites, `app/actions/client.py` now re-exports a thin `MovebankClient` subclass that substitutes `DEFAULT_MOVEBANK_BASE_URL` when `base_url` is missing, `None`, or an empty string. The handlers already import the client through this module, so they pick up the default with no call-site edits. Explicitly configured URLs pass through untouched.

## Testing

- Full action suite passes: `105 passed` (run in `python:3.10-slim`, since the local venv is broken)
- Direct check of the resolution logic: `None` → `https://www.movebank.org`, `""` → `https://www.movebank.org`, `https://custom.example.org` → unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)