### PR TITLE
fix: stop the activity_logger decorator publishing ERROR for rate limits

### DIFF
--- a/app/services/activity_logger.py
+++ b/app/services/activity_logger.py
@@ -26,7 +26,7 @@ from gundi_core.events import (
     CustomWebhookLog,
 )
 from app import settings
-from app.services.errors import format_error_message
+from app.services.errors import classify_error, format_error_message
 
 
 logger = logging.getLogger(__name__)
@@ -148,7 +148,14 @@ def activity_logger(on_start=True, on_completion=True, on_error=True):
             try:
                 result = await func(*args, **kwargs)
             except Exception as e:
-                if on_error:
+                # Provider rate limiting is a recoverable condition owned by
+                # the action runner, which records it as a WARNING custom log
+                # (see execute_action). Publishing IntegrationActionFailed here
+                # too would put an ERROR next to that WARNING and mark the
+                # connection unhealthy — so re-raise and let the runner report.
+                classified = classify_error(e)
+                is_recoverable_rate_limit = classified is not None and classified.error_type == "rate_limit"
+                if on_error and not is_recoverable_rate_limit:
                     await publish_event(
                         event=IntegrationActionFailed(
                             payload=ActionExecutionFailed(

--- a/app/services/tests/test_activity_logger.py
+++ b/app/services/tests/test_activity_logger.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 from unittest.mock import ANY
 from gundi_core.events import (
@@ -66,6 +67,42 @@ async def test_activity_logger_decorator(
     assert mock_publish_event.call_count == 2
     assert isinstance(mock_publish_event.call_args_list[0].kwargs.get("event"), IntegrationActionStarted)
     assert isinstance(mock_publish_event.call_args_list[1].kwargs.get("event"), IntegrationActionComplete)
+
+
+@pytest.mark.asyncio
+async def test_activity_logger_decorator_skips_failed_event_on_rate_limit(
+        mocker, mock_publish_event, integration_v2, pull_observations_config
+):
+    # Provider rate limiting is recorded as a recoverable WARNING by the action
+    # runner (see execute_action). The decorator must NOT also publish an
+    # IntegrationActionFailed for it — that would put an ERROR entry in the
+    # activity feed right next to the runner's WARNING and ding connection
+    # health, defeating the point of the recoverable path.
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+
+    # Same signal shape as production: movebank-client raises with the final
+    # 429 response attached, which classify_error maps to "rate_limit".
+    rate_limited = Exception("Rate limit retries exhausted after 3 attempts over 31.0s")
+    rate_limited.response = httpx.Response(
+        429, request=httpx.Request("GET", "https://www.movebank.org/movebank/service/direct-read")
+    )
+
+    @activity_logger()
+    async def action_pull_observations(integration, action_config):
+        raise rate_limited
+
+    with pytest.raises(Exception, match="Rate limit retries exhausted"):
+        await action_pull_observations(
+            integration=integration_v2,
+            action_config=pull_observations_config
+        )
+
+    # Only the start event — the exception still propagates to the action
+    # runner, which owns the WARNING activity log for rate limits.
+    published = [call.kwargs.get("event") for call in mock_publish_event.call_args_list]
+    assert not any(isinstance(e, IntegrationActionFailed) for e in published)
+    assert mock_publish_event.call_count == 1
+    assert isinstance(published[0], IntegrationActionStarted)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #22. Rate-limited actions were still producing an ERROR activity-log entry ("Error running action 'pull_events_for_individual': Rate limited by the provider — Rate limit retries exhausted after 3 attempts") right next to the recoverable WARNING that #22 introduced.

## Root cause

Two layers publish events when a handler raises, and #22 only fixed one:

1. The `@activity_logger()` decorator wrapping every action handler catches the exception, publishes `IntegrationActionFailed` (rendered as the ERROR entry), then re-raises.
2. The re-raised exception reaches `execute_action`, where #22's change classifies it as `rate_limit` and publishes the WARNING.

The #22 test suite missed this because the runner tests use mock handlers that aren't wrapped by the decorator, so only the runner's path was exercised.

## Fix

The decorator now runs the same `classify_error` check: when the error classifies as `rate_limit` it skips publishing the failure event and just re-raises, leaving the runner as the single owner of the recoverable WARNING.

`webhook_activity_logger` is intentionally unchanged — webhooks don't pass through `execute_action`, so suppressing the failure event there would drop the error entirely.

## Testing

- New test `test_activity_logger_decorator_skips_failed_event_on_rate_limit` exercises the decorator directly with a 429-carrying exception (written first; failed before the fix, passes after)
- Full suite: `232 passed` (run in `python:3.10-slim`)

## Known adjacent issue (not addressed here)

For ordinary (non-rate-limit) failures, both the decorator and the runner's `_handle_error` publish `IntegrationActionFailed`, so normal errors likely produce duplicate ERROR entries. Pre-existing template behavior — tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)