### PR TITLE
Add cancel support for running backfill jobs

### DIFF
--- a/app/actions/backfill_queue.py
+++ b/app/actions/backfill_queue.py
@@ -86,7 +86,8 @@ class BackfillJob:
         """Mark the job cancelled and drop its pending queue + configs so
         nothing new can dispatch. The meta hash (with the flag) survives so
         in-flight steps observe it at their next trigger and unwind; the last
-        one to drain clears the job (see action_backfill_events_for_individual)."""
+        one to drain calls retire_cancelled(), which keeps the flag as a TTL'd
+        tombstone (see action_backfill_events_for_individual)."""
         await self.db.hset(self._meta, mapping={"cancelled": 1})
         await self.db.delete(self._pending, f"{self._meta}.configs")
 

--- a/app/actions/backfill_queue.py
+++ b/app/actions/backfill_queue.py
@@ -90,6 +90,20 @@ class BackfillJob:
         await self.db.hset(self._meta, mapping={"cancelled": 1})
         await self.db.delete(self._pending, f"{self._meta}.configs")
 
+    async def retire_cancelled(self, *, ttl_seconds: int) -> None:
+        """Retire a cancelled job whose in-flight work has drained: drop the
+        working state but leave the meta hash — carrying `cancelled=1` — as a
+        TTL'd tombstone.
+
+        The tombstone is what stops a late or duplicate PubSub delivery (the
+        commands topic is at-least-once, and main.py always acks) from resuming
+        a cancelled backfill: without it `is_cancelled()` would read a missing
+        key as False and the step would fetch from its retained watermark and
+        cascade onward. Bounded by the TTL so it can't leak, and dropped up
+        front by an intentional re-run or restart."""
+        await self.db.delete(self._pending, f"{self._meta}.configs")
+        await self.db.expire(self._meta, ttl_seconds)
+
     async def is_cancelled(self) -> bool:
         value = await self.db.hget(self._meta, "cancelled")
         if isinstance(value, bytes):

--- a/app/actions/backfill_queue.py
+++ b/app/actions/backfill_queue.py
@@ -82,6 +82,20 @@ class BackfillJob:
         double-clicked command hashing to the same job_id."""
         return bool(await self.db.exists(self._meta))
 
+    async def cancel(self) -> None:
+        """Mark the job cancelled and drop its pending queue + configs so
+        nothing new can dispatch. The meta hash (with the flag) survives so
+        in-flight steps observe it at their next trigger and unwind; the last
+        one to drain clears the job (see action_backfill_events_for_individual)."""
+        await self.db.hset(self._meta, mapping={"cancelled": 1})
+        await self.db.delete(self._pending, f"{self._meta}.configs")
+
+    async def is_cancelled(self) -> bool:
+        value = await self.db.hget(self._meta, "cancelled")
+        if isinstance(value, bytes):
+            value = value.decode()
+        return value in ("1", 1)
+
     async def clear(self) -> None:
         """Delete every Redis key for this job (meta hash, pending queue, and the
         per-individual configs hash). Used by a restart to wipe a stuck or

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List, Optional
 
 from dateutil.parser import parse as parse_date
-from pydantic import Field, SecretStr, validator
+from pydantic import Field, SecretStr, root_validator, validator
 
 from app.actions import AuthActionConfiguration, ExecutableActionMixin, PullActionConfiguration
 from app.actions.client import Individual
@@ -69,9 +69,23 @@ class BackfillConfig(GenericActionConfiguration, ExecutableActionMixin):
                     "beginning. Use to recover a stuck backfill. Only use on a stuck job: "
                     "clearing a healthy in-flight job can double-dispatch its remaining work.",
     )
-    ui_global_options = GlobalUISchemaOptions(
-        order=["study_id", "individual_ids", "start", "backfill_max_concurrency", "restart"],
+    cancel: bool = Field(
+        False,
+        title="Cancel",
+        description="Stop the active job for these parameters: nothing new is dispatched and "
+                    "in-flight individuals stop at their next step. Submit with the SAME Study "
+                    "ID, Individual IDs and Start as the running job. Data already sent is "
+                    "kept; re-running the same backfill resumes where cancel stopped it.",
     )
+    ui_global_options = GlobalUISchemaOptions(
+        order=["study_id", "individual_ids", "start", "backfill_max_concurrency", "restart", "cancel"],
+    )
+
+    @root_validator
+    def _cancel_xor_restart(cls, values):
+        if values.get("cancel") and values.get("restart"):
+            raise ValueError("cancel and restart are mutually exclusive — pick one")
+        return values
 
     @validator("start")
     def _validate_start(cls, value):

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -81,6 +81,16 @@ class BackfillConfig(GenericActionConfiguration, ExecutableActionMixin):
         order=["study_id", "individual_ids", "start", "backfill_max_concurrency", "restart", "cancel"],
     )
 
+    @validator("individual_ids")
+    def _canonical_individual_ids(cls, value):
+        # Canonical form: deduped and sorted. The job_id is hashed from these,
+        # and execution filters with set(individual_ids) — so two spellings that
+        # run identically (e.g. a pasted list with a repeat) must hash
+        # identically, or a later cancel/restart won't target the running job.
+        if not value:
+            return value
+        return sorted(set(value))
+
     @root_validator
     def _cancel_xor_restart(cls, values):
         if values.get("cancel") and values.get("restart"):

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -464,17 +464,19 @@ async def action_backfill(integration, action_config: BackfillConfig):
             logger.info(f"Backfill {job_id}: cancel requested but no active job")
             return {"job_id": job_id, "cancelled": False, "active": False}
         snap = await job.snapshot()
+        await job.cancel()
         if snap["in_flight"] > 0:
-            await job.cancel()
             logger.warning(
                 f"Backfill {job_id}: cancelled — dropped {snap['pending_remaining']} pending "
                 f"individuals; {snap['in_flight']} in flight will stop at their next step"
             )
         else:
-            # Nothing running to observe the flag and drain the job, so a lone
-            # cancelled meta hash would just leak — remove the job outright.
-            await job.clear()
-            logger.warning(f"Backfill {job_id}: cancelled idle job — cleared all job state")
+            # Nothing in flight to observe the flag and retire the job, so do it
+            # here. Still a TTL'd tombstone rather than an outright delete: a
+            # duplicate delivery of an already-finalized step can arrive after
+            # in_flight has hit 0, and must not restart the cascade.
+            await job.retire_cancelled(ttl_seconds=settings.CANCELLED_JOB_TOMBSTONE_SECONDS)
+            logger.warning(f"Backfill {job_id}: cancelled idle job — retired with a tombstone")
         return {"job_id": job_id, "cancelled": True,
                 "pending_cleared": snap["pending_remaining"], "in_flight": snap["in_flight"]}
 
@@ -512,7 +514,22 @@ async def action_backfill(integration, action_config: BackfillConfig):
     # flight or already dispatched — double-dispatching them. Bail out early.
     if await job.exists():
         snap = await job.snapshot()
-        if snap["in_flight"] == 0 and snap["pending_remaining"] > 0:
+        if await job.is_cancelled():
+            # A cancelled job (possibly just its TTL'd tombstone) occupies this
+            # job_id. While its in-flight steps are still unwinding, re-seeding
+            # would double-dispatch exactly those individuals — refuse.
+            if snap["in_flight"] > 0:
+                logger.info(
+                    f"Backfill {job_id}: cancelled job still draining "
+                    f"({snap['in_flight']} in flight); not re-seeding"
+                )
+                return {"job_id": job_id, "cancelled_draining": True, "in_flight": snap["in_flight"]}
+            # Fully drained: this run is an intentional re-start of the same
+            # backfill, so drop the tombstone and seed fresh below. Retained
+            # watermarks make each individual resume where cancel stopped it.
+            await job.clear()
+            logger.info(f"Backfill {job_id}: prior run was cancelled and has drained; seeding fresh")
+        elif snap["in_flight"] == 0 and snap["pending_remaining"] > 0:
             # A prior invocation seeded the job (meta + pending) but crashed
             # before/while dispatching — nothing is in flight yet work is still
             # queued. There's no PubSub redelivery to restart it, so a re-run
@@ -532,8 +549,9 @@ async def action_backfill(integration, action_config: BackfillConfig):
                 await _dispatch_backfill_individual(integration_id, job, next_id)
                 dispatched += 1
             return {"job_id": job_id, "resumed": True, "dispatched": dispatched}
-        logger.info(f"Backfill {job_id}: job already active, skipping re-seed")
-        return {"job_id": job_id, "already_active": True}
+        else:
+            logger.info(f"Backfill {job_id}: job already active, skipping re-seed")
+            return {"job_id": job_id, "already_active": True}
 
     # Resolve each individual's backfill end from its steady-state coverage
     # floor. Backfill fills [start, end); the pull owns [end, +inf).
@@ -790,11 +808,14 @@ async def action_backfill_events_for_individual(integration, action_config: Back
             )
         remaining = await job.decr_in_flight()
         if remaining == 0:
-            # Last in-flight unit: nothing else will ever touch this job's keys
-            # (pending/configs were dropped at cancel time), so remove them.
-            await job.clear()
+            # Last in-flight unit: drop the working state, but keep the cancelled
+            # flag as a TTL'd tombstone. A duplicate delivery of an
+            # already-processed step can still arrive (at-least-once), and
+            # without the flag it would read "not cancelled" and resume the
+            # backfill from this individual's retained watermark.
+            await job.retire_cancelled(ttl_seconds=settings.CANCELLED_JOB_TOMBSTONE_SECONDS)
             logger.info(f"Backfill {log_reference}: job cancelled; last in-flight individual "
-                        "stopped — job state cleared")
+                        "stopped — job retired with a tombstone")
         else:
             logger.info(f"Backfill {log_reference}: job cancelled; stopping "
                         f"({remaining} still in flight)")

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -448,7 +448,9 @@ async def action_backfill(integration, action_config: BackfillConfig):
     # same parameters targets it. Deliberately NOT derived from the fetched
     # study membership — that can drift while a whole-study job runs, which
     # would hash a cancel to a different id than the job it's aimed at.
-    ids_repr = sorted(action_config.individual_ids) if action_config.individual_ids else "all"
+    # individual_ids arrives deduped and sorted (BackfillConfig canonicalises it),
+    # so equivalent spellings of the same request hash to the same job.
+    ids_repr = action_config.individual_ids or "all"
     job_seed = f"{action_config.study_id}:{ids_repr}:{action_config.start}"
     job_id = "job-" + hashlib.sha256(job_seed.encode()).hexdigest()[:12]
     job = BackfillJob(integration_id, job_id)

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -442,22 +442,14 @@ async def _seed_pull_cursor_at_end(integration_id: str, study_id: str, ind, end:
 async def action_backfill(integration, action_config: BackfillConfig):
     integration_id = str(integration.id)
     now = datetime.now(tz=timezone.utc)
-    auth_config = client.get_auth_config(integration)
-    mb_client = client.MovebankClient(
-        base_url=integration.base_url,
-        username=auth_config.username,
-        password=auth_config.password.get_secret_value(),
-    )
-    async with mb_client as mb:
-        async with movebank_slot(auth_config.username):
-            rows = await mb.get_individuals_by_study(study_id=action_config.study_id)
-    individuals = list(generate_individuals(rows))
-    if action_config.individual_ids:
-        wanted = set(action_config.individual_ids)
-        individuals = [i for i in individuals if i.id in wanted]
 
-    # Deterministic job id: a redelivered backfill command resumes the same job.
-    job_seed = f"{action_config.study_id}:{sorted(i.id for i in individuals)}:{action_config.start}"
+    # Deterministic job id from the USER-SUPPLIED parameters only: a redelivered
+    # backfill command resumes the same job, and a later cancel/restart with the
+    # same parameters targets it. Deliberately NOT derived from the fetched
+    # study membership — that can drift while a whole-study job runs, which
+    # would hash a cancel to a different id than the job it's aimed at.
+    ids_repr = sorted(action_config.individual_ids) if action_config.individual_ids else "all"
+    job_seed = f"{action_config.study_id}:{ids_repr}:{action_config.start}"
     job_id = "job-" + hashlib.sha256(job_seed.encode()).hexdigest()[:12]
     job = BackfillJob(integration_id, job_id)
 
@@ -466,6 +458,8 @@ async def action_backfill(integration, action_config: BackfillConfig):
         # in-flight individual unwinds at its next step (they carry their
         # config in the PubSub message, so Redis cleanup alone can't stop
         # them — see action_backfill_events_for_individual's entry check).
+        # Handled before any Movebank traffic: cancel stays usable even when
+        # Movebank itself is down or saturated.
         if not await job.exists():
             logger.info(f"Backfill {job_id}: cancel requested but no active job")
             return {"job_id": job_id, "cancelled": False, "active": False}
@@ -483,6 +477,20 @@ async def action_backfill(integration, action_config: BackfillConfig):
             logger.warning(f"Backfill {job_id}: cancelled idle job — cleared all job state")
         return {"job_id": job_id, "cancelled": True,
                 "pending_cleared": snap["pending_remaining"], "in_flight": snap["in_flight"]}
+
+    auth_config = client.get_auth_config(integration)
+    mb_client = client.MovebankClient(
+        base_url=integration.base_url,
+        username=auth_config.username,
+        password=auth_config.password.get_secret_value(),
+    )
+    async with mb_client as mb:
+        async with movebank_slot(auth_config.username):
+            rows = await mb.get_individuals_by_study(study_id=action_config.study_id)
+    individuals = list(generate_individuals(rows))
+    if action_config.individual_ids:
+        wanted = set(action_config.individual_ids)
+        individuals = [i for i in individuals if i.id in wanted]
 
     if action_config.restart:
         # Operator recovery: wipe the deterministic job's state and its

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -461,6 +461,29 @@ async def action_backfill(integration, action_config: BackfillConfig):
     job_id = "job-" + hashlib.sha256(job_seed.encode()).hexdigest()[:12]
     job = BackfillJob(integration_id, job_id)
 
+    if action_config.cancel:
+        # Operator stop: flag the job so nothing new dispatches and every
+        # in-flight individual unwinds at its next step (they carry their
+        # config in the PubSub message, so Redis cleanup alone can't stop
+        # them — see action_backfill_events_for_individual's entry check).
+        if not await job.exists():
+            logger.info(f"Backfill {job_id}: cancel requested but no active job")
+            return {"job_id": job_id, "cancelled": False, "active": False}
+        snap = await job.snapshot()
+        if snap["in_flight"] > 0:
+            await job.cancel()
+            logger.warning(
+                f"Backfill {job_id}: cancelled — dropped {snap['pending_remaining']} pending "
+                f"individuals; {snap['in_flight']} in flight will stop at their next step"
+            )
+        else:
+            # Nothing running to observe the flag and drain the job, so a lone
+            # cancelled meta hash would just leak — remove the job outright.
+            await job.clear()
+            logger.warning(f"Backfill {job_id}: cancelled idle job — cleared all job state")
+        return {"job_id": job_id, "cancelled": True,
+                "pending_cleared": snap["pending_remaining"], "in_flight": snap["in_flight"]}
+
     if action_config.restart:
         # Operator recovery: wipe the deterministic job's state and its
         # per-individual backfill watermarks so it re-seeds and re-runs from
@@ -724,6 +747,16 @@ async def _finalize_backfill_individual(integration_id, job, ind, action_config,
     return {"status": "completed", "observations_sent": observations}
 
 
+def _saved_scan_from(saved) -> Optional[datetime]:
+    """Parse the persisted descent position out of a backfill watermark blob."""
+    if saved and saved.get("scan_from"):
+        try:
+            return _ensure_utc(parse_date(saved["scan_from"]))
+        except Exception:
+            return None
+    return None
+
+
 @activity_logger()
 async def action_backfill_events_for_individual(integration, action_config: BackfillEventsForIndividualConfig):
     ind = action_config.individual
@@ -731,6 +764,33 @@ async def action_backfill_events_for_individual(integration, action_config: Back
     job = BackfillJob(integration_id, action_config.job_id)
     watermark_source = f"{action_config.job_id}.{ind.id}"
     log_reference = f"job:{action_config.job_id},individual:{ind.id}"
+
+    if await job.is_cancelled():
+        # Every continuation path (dispatch, continued, retry, backoff) re-enters
+        # here, so this single check stops the whole cascade within one step.
+        # Carry whatever WAS sent (recent windows first) into the pull cursor so
+        # its settling re-read dedups the seam, and lower coverage_start to the
+        # reached floor — same bookkeeping as the abandon path. The watermark is
+        # kept, so re-running the same backfill resumes this individual.
+        saved = await state_manager.get_state(integration_id, BACKFILL_WATERMARK_ACTION_ID, source_id=watermark_source)
+        if saved:
+            state = IndividualState.parse_obj(saved)
+            reached = _saved_scan_from(saved) or action_config.end
+            await _merge_backfill_into_pull_cursor(
+                integration_id, ind, action_config, state,
+                coverage_start=reached, lower_only=True, create_if_missing=False,
+            )
+        remaining = await job.decr_in_flight()
+        if remaining == 0:
+            # Last in-flight unit: nothing else will ever touch this job's keys
+            # (pending/configs were dropped at cancel time), so remove them.
+            await job.clear()
+            logger.info(f"Backfill {log_reference}: job cancelled; last in-flight individual "
+                        "stopped — job state cleared")
+        else:
+            logger.info(f"Backfill {log_reference}: job cancelled; stopping "
+                        f"({remaining} still in flight)")
+        return {"status": "cancelled"}
 
     sensor_type_ids = _supported_sensor_type_ids(ind)
     if not sensor_type_ids:
@@ -754,12 +814,7 @@ async def action_backfill_events_for_individual(integration, action_config: Back
     # that unmoved cursor and rescan the same empty span forever (livelock).
     # It descends from `end` toward `start`; at any point we have covered
     # `[scan_from, end)` and still owe `[start, scan_from)`.
-    persisted_scan_from = None
-    if saved and saved.get("scan_from"):
-        try:
-            persisted_scan_from = _ensure_utc(parse_date(saved["scan_from"]))
-        except Exception:
-            persisted_scan_from = None
+    persisted_scan_from = _saved_scan_from(saved)
 
     auth_config = client.get_auth_config(integration)
     deadline = time.monotonic() + 0.8 * settings.MAX_ACTION_EXECUTION_TIME

--- a/app/actions/tests/conftest.py
+++ b/app/actions/tests/conftest.py
@@ -83,3 +83,74 @@ INDIVIDUAL_ROW = {
     "sensor_type_ids": "gps",
     "taxon_detail": "",
 }
+
+
+@pytest.fixture
+def fake_backfill_redis():
+    """Minimal in-memory stand-in for the subset of redis.asyncio that
+    BackfillJob uses. Hashes are keyed by their Redis key so distinct hashes
+    (meta vs. the per-individual configs hash) don't collide on field names.
+    Shared by the queue unit tests and the handler tests that need real
+    key-level semantics (e.g. whether a flag survives a cleanup)."""
+    store = {"hashes": {}, "list": [], "ttls": {}}
+
+    client = MagicMock()
+
+    async def hincrby(key, field, n):
+        h = store["hashes"].setdefault(key, {})
+        h[field] = int(h.get(field, 0)) + n
+        return h[field]
+
+    async def hset(key, mapping=None, **kw):
+        h = store["hashes"].setdefault(key, {})
+        h.update(mapping or kw)
+
+    async def hgetall(key):
+        return {k: str(v) for k, v in store["hashes"].get(key, {}).items()}
+
+    async def hget(key, field):
+        return store["hashes"].get(key, {}).get(field)
+
+    async def hdel(key, *fields):
+        h = store["hashes"].get(key, {})
+        for f in fields:
+            h.pop(f, None)
+
+    async def exists(key):
+        return 1 if store["hashes"].get(key) else 0
+
+    async def rpush(key, *vals):
+        store["list"].extend(vals)
+        return len(store["list"])
+
+    async def lpop(key):
+        return store["list"].pop(0) if store["list"] else None
+
+    async def llen(key):
+        return len(store["list"])
+
+    async def delete(*keys):
+        for key in keys:
+            store["hashes"].pop(key, None)
+            store["ttls"].pop(key, None)
+            if key.endswith(".pending"):
+                store["list"].clear()
+
+    async def expire(key, seconds):
+        store["ttls"][key] = seconds
+        return 1
+
+    client.hincrby = AsyncMock(side_effect=hincrby)
+    client.hset = AsyncMock(side_effect=hset)
+    client.hgetall = AsyncMock(side_effect=hgetall)
+    client.hget = AsyncMock(side_effect=hget)
+    client.hdel = AsyncMock(side_effect=hdel)
+    client.exists = AsyncMock(side_effect=exists)
+    client.rpush = AsyncMock(side_effect=rpush)
+    client.lpop = AsyncMock(side_effect=lpop)
+    client.llen = AsyncMock(side_effect=llen)
+    client.delete = AsyncMock(side_effect=delete)
+    client.expire = AsyncMock(side_effect=expire)
+    # Expose the backing store so tests can assert TTLs and simulate expiry.
+    client.store = store
+    return client

--- a/app/actions/tests/test_backfill_queue.py
+++ b/app/actions/tests/test_backfill_queue.py
@@ -47,7 +47,14 @@ def fake_redis():
     async def llen(key):
         return len(store["list"])
 
+    async def delete(*keys):
+        for key in keys:
+            store["hashes"].pop(key, None)
+            if key.endswith(".pending"):
+                store["list"].clear()
+
     client.hincrby = AsyncMock(side_effect=hincrby)
+    client.delete = AsyncMock(side_effect=delete)
     client.hset = AsyncMock(side_effect=hset)
     client.hgetall = AsyncMock(side_effect=hgetall)
     client.hget = AsyncMock(side_effect=hget)
@@ -149,6 +156,35 @@ async def test_exists_false_before_seed_true_after(job):
     assert await job.exists() is False
     await job.seed(["a"], total=1, range_repr="r")
     assert await job.exists() is True
+
+
+@pytest.mark.asyncio
+async def test_is_cancelled_false_by_default(job):
+    await job.seed(["a"], total=1, range_repr="r")
+    assert await job.is_cancelled() is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_marks_job_and_drops_pending_and_configs(job):
+    await job.seed(["a", "b"], total=2, range_repr="r")
+    await job.put_individual_config("a", '{"x": 1}')
+    await job.cancel()
+    assert await job.is_cancelled() is True
+    # The meta hash survives so in-flight steps still see the flag ...
+    assert await job.exists() is True
+    # ... but nothing new can dispatch: pending queue and configs are gone.
+    assert await job.next_individual() is None
+    assert await job.get_individual_config("a") is None
+
+
+@pytest.mark.asyncio
+async def test_clear_removes_cancelled_flag(job):
+    # restart=true recovers a cancelled job: clear() wipes the flag along with
+    # the rest of the meta hash.
+    await job.seed(["a"], total=1, range_repr="r")
+    await job.cancel()
+    await job.clear()
+    assert await job.is_cancelled() is False
 
 
 @pytest.mark.asyncio

--- a/app/actions/tests/test_backfill_queue.py
+++ b/app/actions/tests/test_backfill_queue.py
@@ -1,74 +1,11 @@
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 
 from app.actions.backfill_queue import BackfillJob
 
 
 @pytest.fixture
-def fake_redis():
-    # Minimal in-memory stand-in for the subset of redis.asyncio used here.
-    # Hashes are keyed by their Redis key so distinct hashes (meta vs. the
-    # per-individual configs hash) don't collide on field names.
-    store = {"hashes": {}, "list": []}
-
-    client = MagicMock()
-
-    async def hincrby(key, field, n):
-        h = store["hashes"].setdefault(key, {})
-        h[field] = int(h.get(field, 0)) + n
-        return h[field]
-
-    async def hset(key, mapping=None, **kw):
-        h = store["hashes"].setdefault(key, {})
-        h.update(mapping or kw)
-
-    async def hgetall(key):
-        return {k: str(v) for k, v in store["hashes"].get(key, {}).items()}
-
-    async def hget(key, field):
-        return store["hashes"].get(key, {}).get(field)
-
-    async def hdel(key, *fields):
-        h = store["hashes"].get(key, {})
-        for f in fields:
-            h.pop(f, None)
-
-    async def exists(key):
-        return 1 if store["hashes"].get(key) else 0
-
-    async def rpush(key, *vals):
-        store["list"].extend(vals)
-        return len(store["list"])
-
-    async def lpop(key):
-        return store["list"].pop(0) if store["list"] else None
-
-    async def llen(key):
-        return len(store["list"])
-
-    async def delete(*keys):
-        for key in keys:
-            store["hashes"].pop(key, None)
-            if key.endswith(".pending"):
-                store["list"].clear()
-
-    client.hincrby = AsyncMock(side_effect=hincrby)
-    client.delete = AsyncMock(side_effect=delete)
-    client.hset = AsyncMock(side_effect=hset)
-    client.hgetall = AsyncMock(side_effect=hgetall)
-    client.hget = AsyncMock(side_effect=hget)
-    client.hdel = AsyncMock(side_effect=hdel)
-    client.exists = AsyncMock(side_effect=exists)
-    client.rpush = AsyncMock(side_effect=rpush)
-    client.lpop = AsyncMock(side_effect=lpop)
-    client.llen = AsyncMock(side_effect=llen)
-    return client
-
-
-@pytest.fixture
-def job(mocker, fake_redis):
-    mocker.patch("app.actions.backfill_queue._client", return_value=fake_redis)
+def job(mocker, fake_backfill_redis):
+    mocker.patch("app.actions.backfill_queue._client", return_value=fake_backfill_redis)
     return BackfillJob("int-1", "job-1")
 
 
@@ -196,3 +133,32 @@ async def test_requeue_returns_individual_to_pending(job):
     assert await job.next_individual() == "b"
     assert await job.next_individual() == "a"
     assert await job.next_individual() is None
+
+
+@pytest.mark.asyncio
+async def test_retire_cancelled_keeps_flag_and_expires_the_meta_hash(job, fake_backfill_redis):
+    # The last in-flight step of a cancelled job retires it: working state goes
+    # away, but the cancelled flag SURVIVES so a late/duplicate PubSub delivery
+    # for the same job still short-circuits instead of resuming the backfill.
+    await job.seed(["a", "b"], total=2, range_repr="r")
+    await job.put_individual_config("a", '{"x": 1}')
+    await job.cancel()
+
+    await job.retire_cancelled(ttl_seconds=3600)
+
+    assert await job.is_cancelled() is True
+    assert await job.next_individual() is None
+    assert await job.get_individual_config("a") is None
+    # The tombstone is bounded — it expires rather than leaking forever.
+    assert fake_backfill_redis.store["ttls"][job._meta] == 3600
+
+
+@pytest.mark.asyncio
+async def test_retired_tombstone_stops_reporting_cancelled_once_expired(job, fake_backfill_redis):
+    await job.seed(["a"], total=1, range_repr="r")
+    await job.cancel()
+    await job.retire_cancelled(ttl_seconds=3600)
+    # Simulate Redis expiring the tombstone: the job is simply gone again.
+    fake_backfill_redis.store["hashes"].pop(job._meta)
+    assert await job.is_cancelled() is False
+    assert await job.exists() is False

--- a/app/actions/tests/test_configurations.py
+++ b/app/actions/tests/test_configurations.py
@@ -99,3 +99,10 @@ def test_backfill_individual_config_is_internal_and_roundtrips():
     restored = BackfillEventsForIndividualConfig.parse_obj(cfg.dict())
     assert restored.individual.id == "111"
     assert restored.job_id == "job-1"
+
+
+def test_backfill_config_rejects_cancel_and_restart_together():
+    from app.actions.configurations import BackfillConfig
+    import pydantic
+    with pytest.raises(pydantic.ValidationError):
+        BackfillConfig(study_id="12345", start="all", cancel=True, restart=True)

--- a/app/actions/tests/test_configurations.py
+++ b/app/actions/tests/test_configurations.py
@@ -106,3 +106,11 @@ def test_backfill_config_rejects_cancel_and_restart_together():
     import pydantic
     with pytest.raises(pydantic.ValidationError):
         BackfillConfig(study_id="12345", start="all", cancel=True, restart=True)
+
+
+def test_backfill_config_normalizes_individual_ids():
+    from app.actions.configurations import BackfillConfig
+    # Execution dedups these via set(), so the canonical form must too — the
+    # job_id is hashed from them, and cancel/restart have to reproduce it.
+    config = BackfillConfig(study_id="12345", start="all", individual_ids=["222", "111", "222"])
+    assert config.individual_ids == ["111", "222"]

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -2516,3 +2516,39 @@ async def test_backfill_reseeds_fresh_after_cancelled_job_fully_drained(
     mock_seed.assert_awaited_once()            # fresh seed, not already_active
     assert result.get("already_active") is None
     assert result["individuals"] == 1
+
+
+@pytest.mark.asyncio
+async def test_backfill_cancel_targets_job_despite_duplicate_individual_ids(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    # A pasted list with a duplicate executes for the same effective individuals,
+    # so it must hash to the same job — otherwise a cancel typed without the
+    # duplicate reports "no active job" while the job keeps running.
+    rows = [{**INDIVIDUAL_ROW, "id": "111"}, {**INDIVIDUAL_ROW, "id": "222"}]
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=rows)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=False))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.put_individual_config", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    started = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all", individual_ids=["111", "111"]),
+    )
+
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_cancelled", AsyncMock(return_value=False))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 1, "completed": 0, "observations_sent": 0,
+                                         "in_flight": 1, "pending_remaining": 0, "range": "r"}))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.cancel", AsyncMock())
+
+    cancelled = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all", individual_ids=["111"], cancel=True),
+    )
+
+    assert cancelled["cancelled"] is True
+    assert cancelled["job_id"] == started["job_id"]

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -82,10 +82,13 @@ def _make_individual(**overrides):
 
 
 @pytest.fixture(autouse=True)
-def job_not_cancelled(mocker):
+def job_not_cancelled(mocker, request):
     """The per-individual step checks the job's cancelled flag in Redis at
     entry; stub it False by default so handler tests don't need a live Redis.
-    Cancellation tests re-patch it explicitly."""
+    Cancellation tests re-patch it explicitly, and tests that request
+    fake_backfill_redis drive the real BackfillJob against the in-memory fake."""
+    if "fake_backfill_redis" in request.fixturenames:
+        return
     mocker.patch("app.actions.backfill_queue.BackfillJob.is_cancelled", AsyncMock(return_value=False))
 
 
@@ -2248,17 +2251,20 @@ async def test_backfill_cancel_flags_active_job_and_stops_dispatch(
 
 
 @pytest.mark.asyncio
-async def test_backfill_cancel_idle_job_clears_state_immediately(
+async def test_backfill_cancel_idle_job_retires_it_with_a_tombstone(
         mocker, integration, mock_auth_config, mock_movebank_client
 ):
-    # Nothing in flight -> no step will ever observe the cancelled flag and
-    # drain the job, so cancel removes the job state outright.
+    # Nothing in flight -> no step will ever observe the flag and retire the
+    # job, so cancel retires it here. Still a TTL'd tombstone rather than an
+    # outright delete: a duplicate delivery of an already-finalized step can
+    # arrive after in_flight hit 0 and must not restart the cascade.
     mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[INDIVIDUAL_ROW])
     mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=True))
     mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
                  AsyncMock(return_value={"total": 5, "completed": 2, "observations_sent": 10,
                                          "in_flight": 0, "pending_remaining": 3, "range": "r"}))
     mock_cancel = mocker.patch("app.actions.backfill_queue.BackfillJob.cancel", AsyncMock())
+    mock_retire = mocker.patch("app.actions.backfill_queue.BackfillJob.retire_cancelled", AsyncMock())
     mock_clear = mocker.patch("app.actions.backfill_queue.BackfillJob.clear", AsyncMock())
     mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
 
@@ -2268,8 +2274,9 @@ async def test_backfill_cancel_idle_job_clears_state_immediately(
     )
 
     assert result["cancelled"] is True
-    mock_clear.assert_awaited_once()
-    assert not mock_cancel.called
+    mock_cancel.assert_awaited_once()
+    mock_retire.assert_awaited_once()
+    assert not mock_clear.called       # the flag must survive, so never a bare delete
     assert not mock_trigger.called
 
 
@@ -2344,13 +2351,14 @@ async def test_backfill_individual_cancelled_job_stops_and_keeps_partial_coverag
 
 
 @pytest.mark.asyncio
-async def test_backfill_individual_cancel_clears_job_when_last_in_flight(
+async def test_backfill_individual_cancel_retires_job_when_last_in_flight(
         mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
 ):
     start = datetime(2024, 1, 1, tzinfo=timezone.utc)
     end = datetime(2024, 1, 10, tzinfo=timezone.utc)
     mocker.patch("app.actions.backfill_queue.BackfillJob.is_cancelled", AsyncMock(return_value=True))
     mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mock_retire = mocker.patch("app.actions.backfill_queue.BackfillJob.retire_cancelled", AsyncMock())
     mock_clear = mocker.patch("app.actions.backfill_queue.BackfillJob.clear", AsyncMock())
     mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
 
@@ -2362,7 +2370,10 @@ async def test_backfill_individual_cancel_clears_job_when_last_in_flight(
     )
 
     assert result["status"] == "cancelled"
-    mock_clear.assert_awaited_once()       # last in-flight unit removes the job state
+    # The last in-flight unit drops the working state but KEEPS the cancelled
+    # flag, so a late duplicate delivery still short-circuits.
+    mock_retire.assert_awaited_once()
+    assert not mock_clear.called
     assert not mock_trigger.called
 
 
@@ -2404,3 +2415,104 @@ async def test_backfill_cancel_job_id_stable_across_study_membership_drift(
     assert result["cancelled"] is True
     assert result["job_id"] == started["job_id"]
     mock_cancel.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_delivery_after_cancelled_job_drains_still_stops(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store,
+        fake_backfill_redis,
+):
+    # PubSub is at-least-once and main.py always acks, so a duplicate delivery
+    # of an already-processed step can arrive after the cancelled job drained.
+    # It must NOT resume the backfill (the watermark is deliberately kept so an
+    # intentional re-run can resume, which is exactly what makes this dangerous).
+    from app.actions.backfill_queue import BackfillJob
+    mocker.patch("app.actions.backfill_queue._client", return_value=fake_backfill_redis)
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 10, tzinfo=timezone.utc)
+    iid = str(integration.id)
+    mock_state_store[(iid, "backfill_watermark", "job-1.111")] = {
+        "individual_id": "111", "study_id": "12345", "local_identifier": "tag-1",
+        "sensor_states": {"653": {"latest_timestamp": "2024-01-09T00:00:00+00:00", "highest_event_id": 50}},
+        "scan_from": "2024-01-04T00:00:00+00:00",
+    }
+    job = BackfillJob(iid, "job-1")
+    await job.seed(["111"], total=1, range_repr="r")
+    await job.incr_in_flight()
+    await job.cancel()
+
+    fetch = AsyncMock()
+    mock_movebank_client.get_individual_events_by_time = fetch
+    mock_send = mocker.patch("app.actions.handlers.send_observations_to_gundi", AsyncMock(return_value=[]))
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+    cfg = BackfillEventsForIndividualConfig(
+        study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+    )
+
+    first = await action_backfill_events_for_individual(integration=integration, action_config=cfg)
+    assert first["status"] == "cancelled"
+
+    # Duplicate delivery of the SAME message, after the job has fully drained.
+    second = await action_backfill_events_for_individual(integration=integration, action_config=cfg)
+
+    assert second["status"] == "cancelled"
+    assert not fetch.called          # no Movebank traffic
+    assert not mock_send.called      # no observations resent
+    assert not mock_trigger.called   # no cascade restarted
+
+
+@pytest.mark.asyncio
+async def test_backfill_refuses_to_reseed_while_cancelled_job_is_draining(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    # Re-running the same backfill while in-flight steps are still unwinding
+    # would double-dispatch those individuals. Refuse until they've drained.
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[INDIVIDUAL_ROW])
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_cancelled", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 2, "completed": 0, "observations_sent": 0,
+                                         "in_flight": 2, "pending_remaining": 0, "range": "r"}))
+    mock_seed = mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
+    mock_clear = mocker.patch("app.actions.backfill_queue.BackfillJob.clear", AsyncMock())
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all"),
+    )
+
+    assert result["cancelled_draining"] is True
+    assert result["in_flight"] == 2
+    assert not mock_seed.called
+    assert not mock_clear.called
+    assert not mock_trigger.called
+
+
+@pytest.mark.asyncio
+async def test_backfill_reseeds_fresh_after_cancelled_job_fully_drained(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    # Tombstone left by a fully-drained cancelled job must not block an
+    # intentional re-run: clear it and seed fresh (watermarks make it resume).
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[INDIVIDUAL_ROW])
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_cancelled", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 0, "completed": 0, "observations_sent": 0,
+                                         "in_flight": 0, "pending_remaining": 0, "range": "r"}))
+    mock_clear = mocker.patch("app.actions.backfill_queue.BackfillJob.clear", AsyncMock())
+    mock_seed = mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.put_individual_config", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all"),
+    )
+
+    mock_clear.assert_awaited_once()          # tombstone dropped
+    mock_seed.assert_awaited_once()            # fresh seed, not already_active
+    assert result.get("already_active") is None
+    assert result["individuals"] == 1

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -81,6 +81,14 @@ def _make_individual(**overrides):
     return Individual.parse_obj({**INDIVIDUAL_ROW, **overrides})
 
 
+@pytest.fixture(autouse=True)
+def job_not_cancelled(mocker):
+    """The per-individual step checks the job's cancelled flag in Redis at
+    entry; stub it False by default so handler tests don't need a live Redis.
+    Cancellation tests re-patch it explicitly."""
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_cancelled", AsyncMock(return_value=False))
+
+
 @pytest.fixture
 def mock_state_store(mocker):
     """In-memory stand-in for the module-level state_manager in handlers."""
@@ -2208,3 +2216,151 @@ async def test_merge_into_pull_cursor_skips_write_when_unchanged(mocker, integra
         coverage_start=end, lower_only=True, create_if_missing=False,
     )
     assert set_state.called
+
+
+@pytest.mark.asyncio
+async def test_backfill_cancel_flags_active_job_and_stops_dispatch(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[INDIVIDUAL_ROW])
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 5, "completed": 1, "observations_sent": 10,
+                                         "in_flight": 2, "pending_remaining": 2, "range": "r"}))
+    mock_cancel = mocker.patch("app.actions.backfill_queue.BackfillJob.cancel", AsyncMock())
+    mock_clear = mocker.patch("app.actions.backfill_queue.BackfillJob.clear", AsyncMock())
+    mock_seed = mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all", cancel=True),
+    )
+
+    assert result["cancelled"] is True
+    assert result["in_flight"] == 2
+    assert result["pending_cleared"] == 2
+    mock_cancel.assert_awaited_once()
+    # In-flight steps observe the flag and drain/clear the job themselves.
+    assert not mock_clear.called
+    assert not mock_seed.called
+    assert not mock_trigger.called
+
+
+@pytest.mark.asyncio
+async def test_backfill_cancel_idle_job_clears_state_immediately(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    # Nothing in flight -> no step will ever observe the cancelled flag and
+    # drain the job, so cancel removes the job state outright.
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[INDIVIDUAL_ROW])
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 5, "completed": 2, "observations_sent": 10,
+                                         "in_flight": 0, "pending_remaining": 3, "range": "r"}))
+    mock_cancel = mocker.patch("app.actions.backfill_queue.BackfillJob.cancel", AsyncMock())
+    mock_clear = mocker.patch("app.actions.backfill_queue.BackfillJob.clear", AsyncMock())
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all", cancel=True),
+    )
+
+    assert result["cancelled"] is True
+    mock_clear.assert_awaited_once()
+    assert not mock_cancel.called
+    assert not mock_trigger.called
+
+
+@pytest.mark.asyncio
+async def test_backfill_cancel_without_active_job_reports_inactive(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=[INDIVIDUAL_ROW])
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=False))
+    mock_cancel = mocker.patch("app.actions.backfill_queue.BackfillJob.cancel", AsyncMock())
+    mock_clear = mocker.patch("app.actions.backfill_queue.BackfillJob.clear", AsyncMock())
+    mock_seed = mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all", cancel=True),
+    )
+
+    assert result["cancelled"] is False
+    assert not mock_cancel.called
+    assert not mock_clear.called
+    assert not mock_seed.called
+    assert not mock_trigger.called
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_cancelled_job_stops_and_keeps_partial_coverage(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 10, tzinfo=timezone.utc)
+    iid = str(integration.id)
+    # The reverse descent reached 2024-01-04: [01-04 .. 01-10) already sent.
+    mock_state_store[(iid, "backfill_watermark", "job-1.111")] = {
+        "individual_id": "111", "study_id": "12345", "local_identifier": "tag-1",
+        "sensor_states": {"653": {"latest_timestamp": "2024-01-09T00:00:00+00:00", "highest_event_id": 50}},
+        "scan_from": "2024-01-04T00:00:00+00:00",
+    }
+    # Existing pull cursor: coverage floor still at the job's end boundary.
+    mock_state_store[(iid, "pull_events_for_individual", "111")] = {
+        "individual_id": "111", "study_id": "12345",
+        "sensor_states": {"653": {"latest_timestamp": "2024-01-08T00:00:00+00:00", "highest_event_id": 40}},
+        "coverage_start": "2024-01-10T00:00:00+00:00",
+    }
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_cancelled", AsyncMock(return_value=True))
+    mock_decr = mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=1))
+    mock_clear = mocker.patch("app.actions.backfill_queue.BackfillJob.clear", AsyncMock())
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+    fetch = AsyncMock()
+    mock_movebank_client.get_individual_events_by_time = fetch
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "cancelled"
+    mock_decr.assert_awaited_once()
+    assert not fetch.called                # no Movebank traffic
+    assert not mock_trigger.called         # no re-trigger, no dispatch-next
+    assert not mock_clear.called           # not the last in-flight unit
+    cursor = IndividualState.parse_obj(mock_state_store[(iid, "pull_events_for_individual", "111")])
+    # Coverage floor lowered to the reached descent position, not to `start`.
+    assert cursor.coverage_start == datetime(2024, 1, 4, tzinfo=timezone.utc)
+    # Sent windows' maxima carried forward so the pull's settling re-read dedups the seam.
+    assert cursor.get_sensor_state(653).highest_event_id == 50
+    # Watermark kept so a re-run of the same job resumes this individual.
+    assert (iid, "backfill_watermark", "job-1.111") in mock_state_store
+
+
+@pytest.mark.asyncio
+async def test_backfill_individual_cancel_clears_job_when_last_in_flight(
+        mocker, integration, mock_auth_config, mock_movebank_client, mock_state_store
+):
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 10, tzinfo=timezone.utc)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.is_cancelled", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.decr_in_flight", AsyncMock(return_value=0))
+    mock_clear = mocker.patch("app.actions.backfill_queue.BackfillJob.clear", AsyncMock())
+    mock_trigger = mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    result = await action_backfill_events_for_individual(
+        integration=integration,
+        action_config=BackfillEventsForIndividualConfig(
+            study_id="12345", individual=INDIVIDUAL_ROW, job_id="job-1", start=start, end=end,
+        ),
+    )
+
+    assert result["status"] == "cancelled"
+    mock_clear.assert_awaited_once()       # last in-flight unit removes the job state
+    assert not mock_trigger.called

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -2364,3 +2364,43 @@ async def test_backfill_individual_cancel_clears_job_when_last_in_flight(
     assert result["status"] == "cancelled"
     mock_clear.assert_awaited_once()       # last in-flight unit removes the job state
     assert not mock_trigger.called
+
+
+@pytest.mark.asyncio
+async def test_backfill_cancel_job_id_stable_across_study_membership_drift(
+        mocker, integration, mock_auth_config, mock_movebank_client
+):
+    # Seed a whole-study job while the study has 2 individuals.
+    rows = [{**INDIVIDUAL_ROW, "id": "1"}, {**INDIVIDUAL_ROW, "id": "2"}]
+    mock_movebank_client.get_individuals_by_study = AsyncMock(return_value=rows)
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=False))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.seed", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.put_individual_config", AsyncMock())
+    mocker.patch("app.actions.backfill_queue.BackfillJob.next_individual", AsyncMock(return_value=None))
+    mocker.patch("app.actions.handlers.trigger_action", AsyncMock())
+
+    started = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all"),
+    )
+
+    # Study membership changed since the job started. Cancel must hash to the
+    # SAME job from the user-supplied parameters alone — it must not depend on
+    # a live Movebank fetch (which could also be down mid-incident).
+    mock_movebank_client.get_individuals_by_study = AsyncMock(
+        side_effect=AssertionError("cancel must not fetch study individuals")
+    )
+    mocker.patch("app.actions.backfill_queue.BackfillJob.exists", AsyncMock(return_value=True))
+    mocker.patch("app.actions.backfill_queue.BackfillJob.snapshot",
+                 AsyncMock(return_value={"total": 2, "completed": 0, "observations_sent": 0,
+                                         "in_flight": 1, "pending_remaining": 1, "range": "r"}))
+    mock_cancel = mocker.patch("app.actions.backfill_queue.BackfillJob.cancel", AsyncMock())
+
+    result = await action_backfill(
+        integration=integration,
+        action_config=BackfillConfig(study_id="12345", start="all", cancel=True),
+    )
+
+    assert result["cancelled"] is True
+    assert result["job_id"] == started["job_id"]
+    mock_cancel.assert_awaited_once()

--- a/app/settings/integration.py
+++ b/app/settings/integration.py
@@ -25,3 +25,10 @@ MIN_BACKFILL_WINDOW_SECONDS = env.int("MIN_BACKFILL_WINDOW_SECONDS", 300)
 # Safety factor when proportionally shrinking the window on overflow, so the
 # resized window aims comfortably below the cap rather than exactly at it.
 BACKFILL_WINDOW_SHRINK_SAFETY = env.float("BACKFILL_WINDOW_SHRINK_SAFETY", 0.8)
+# How long a cancelled backfill job's tombstone lives after the job has drained.
+# PubSub is at-least-once, so a duplicate delivery of an already-processed step
+# can arrive after the job's working state is gone; the tombstone is what makes
+# that late step short-circuit instead of resuming a cancelled backfill. Keep it
+# comfortably above the commands subscription's message-retention window. It is
+# one small key per cancelled job, and an intentional re-run drops it up front.
+CANCELLED_JOB_TOMBSTONE_SECONDS = env.int("CANCELLED_JOB_TOMBSTONE_SECONDS", 86400)


### PR DESCRIPTION
## What

Adds a **Cancel** option to the Backfill action so an operator can stop a running backfill job. Submitting the Backfill action with the **same Study ID, Individual IDs, and Start** as the running job (which reproduces its deterministic `job_id`) plus `cancel=true`:

- immediately stops anything new from dispatching (pending queue + per-individual configs are dropped), and
- stops every in-flight individual at its next step — worst case one execution budget of latency each.

## Why

A backfill runs as a self-perpetuating PubSub cascade: each per-individual step re-triggers itself (`continued`/`retry`/`backoff`) with its config carried **in the message**, and finalize dispatches the next pending individual from Redis. There was no way to stop one:

- Deleting the job's Redis keys only stops *new* dispatches — in-flight individuals keep cascading through their entire date range.
- Worse, their finalize step's `hincrby` calls silently **recreate** the deleted meta hash, which is one source of the leaked `backfill.*` keys.

## How

- `BackfillJob.cancel()` sets a `cancelled` flag on the meta hash and deletes the pending queue and configs hash. The meta hash deliberately survives so in-flight steps can still observe the flag.
- `action_backfill_events_for_individual` checks the flag **at entry**. Every continuation path re-enters there, so a single check stops the whole cascade. On cancel it reuses the abandon path's bookkeeping: already-sent windows merge into the pull cursor (`lower_only`) so the settling re-read dedups the seam and `coverage_start` honestly reflects the reached descent position — no duplicate observations, no falsely-claimed coverage.
- The **last** in-flight unit to drain calls `retire_cancelled()`: it drops the working state but `EXPIRE`s the meta hash, leaving the `cancelled` flag as a bounded **tombstone** (`CANCELLED_JOB_TOMBSTONE_SECONDS`, default 24h). PubSub is at-least-once and `main.py` always acks, so a duplicate delivery of an already-processed step can arrive after the job drained; without the flag it would read "not cancelled" and resume from the retained watermark. This also closes the recreate-after-delete key leak.
- The seed guard treats a cancelled job explicitly: **refuse** to re-seed while in-flight steps are still unwinding (that would double-dispatch exactly those individuals), and once fully drained **drop the tombstone and seed fresh**. Retained watermarks (same as the abandon path) make each individual resume where cancel stopped it.
- The job id is derived from the **user-supplied parameters only** (`study_id`, `individual_ids` or `"all"`, `start`) rather than the live-fetched study membership, which can drift while a whole-study job runs and would otherwise hash a cancel to a different id than the job it targets. Cancel therefore also runs before any Movebank traffic, so it works even when Movebank is down or saturated.
- `cancel` and `restart` are mutually exclusive (validator); `restart=true` still wipes everything including the flag.

## Notes for reviewers

- Cancellation granularity is per-**step**, not per-window: a step already executing finishes its current budget (~0.8 × `MAX_ACTION_EXECUTION_TIME`) before its continuation hits the entry check. This keeps the change minimal and the window-loop untouched.
- Residual boundary: the tombstone defends for its TTL. A duplicate arriving *after* 24h would still resume the individual — far beyond any practical redelivery window, and the TTL is env-tunable.
- Deploy note: a job started before this change can't be targeted by cancel/restart (its id was hashed differently). It still runs and finishes normally, since the cascade carries `job_id` in the messages.
- Test scaffolding: the fake Redis moved from `test_backfill_queue.py` into `conftest.py` (plus `EXPIRE`) so handler tests can drive a real `BackfillJob` through cancel → drain → duplicate delivery against actual key semantics.
- Tests: 15 new (queue semantics incl. tombstone survival/expiry, all cancel outcomes of `action_backfill`, in-flight unwind with partial-coverage merge, last-unit retire, duplicate-delivery regression, seed-guard draining/re-seed, job-id stability under membership drift, config validator). Full suite: **247 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)